### PR TITLE
🐞 Bugfix: all hooks/composables/etc support retrieving repositories for custom connections

### DIFF
--- a/packages/core/shared-utils/integrationsHelpers.ts
+++ b/packages/core/shared-utils/integrationsHelpers.ts
@@ -29,9 +29,9 @@ function getAllKeys<T extends Record<any, any>>(obj: T): Array<keyof T> {
 export function useRepositoryForDynamicContext<
   R extends Repository<InstanceType<M>>,
   M extends typeof Model = typeof Model,
->(contextRetriever: ContextRetriever, model: M): UseRepository<R> {
+>(contextRetriever: ContextRetriever, model: M, connection: string = 'entities'): UseRepository<R> {
   const context = contextRetriever()
-  const repo = context.$repo<R, M>(model)
+  const repo = context.$repo<R, M>(model, connection)
   const allRepoKeys = getAllKeys(repo)
   const result = {} as UseRepository<R>
 

--- a/packages/core/shared-utils/reactTestUtils.tsx
+++ b/packages/core/shared-utils/reactTestUtils.tsx
@@ -11,7 +11,7 @@ import type { DataProvider, RattusOrmInstallerOptions } from '../src'
 import { Database } from '../src'
 import type { RattusContext } from '../src/context/rattus-context'
 import type { UseRepository } from './integrationsHelpers'
-import { testContext, testMethodsBound, testMethodsNotRuined, TestUser } from './testUtils'
+import { testContext, testCustomConnection, testMethodsBound, testMethodsNotRuined, TestUser } from './testUtils'
 
 type RattusRenderProps<T> = {
   ContextComp: JSXElementConstructor<any>
@@ -103,16 +103,16 @@ export function createReactIntegrationTest({
   componentsWrapper,
 }: ReactIntegrationTestParams) {
   describe(`${name} react integration test`, () => {
-    describe(`${name}: context`, () => {
-      function renderHook<T>(hook: () => T, props?: RattusOrmInstallerOptions): T {
-        return renderHookWithContext({
-          hook,
-          ContextComp: Provider,
-          contextProps: props,
-          bootstrap,
-        })
-      }
+    function renderHook<T>(hook: () => T, props?: RattusOrmInstallerOptions): T {
+      return renderHookWithContext({
+        hook,
+        ContextComp: Provider,
+        contextProps: props,
+        bootstrap,
+      })
+    }
 
+    describe(`${name}: context`, () => {
       const TestComponent = componentsWrapper
         ? componentsWrapper(createTestComponent(useRattusContextHook))
         : createTestComponent(useRattusContextHook)
@@ -181,6 +181,8 @@ export function createReactIntegrationTest({
         }).result,
         act,
       )
+
+      testCustomConnection(name, renderHook(useRattusContextHook))
 
       it(`${name}: useRepository returns reactive data`, async () => {
         const {

--- a/packages/core/src/context/rattus-context.ts
+++ b/packages/core/src/context/rattus-context.ts
@@ -74,8 +74,9 @@ export class RattusContext {
     model: M,
     connection?: string,
   ): R {
-    if (this.storedRepos.has(model.entity)) {
-      return this.storedRepos.get(model.entity) as R
+    const cacheKey = [connection, model.entity].join('::')
+    if (this.storedRepos.has(cacheKey)) {
+      return this.storedRepos.get(cacheKey) as R
     }
 
     let localDb: Database
@@ -92,7 +93,7 @@ export class RattusContext {
     }
 
     const repo = localDb.getRepository<R>(model)
-    this.storedRepos.set(model.entity, repo)
+    this.storedRepos.set(cacheKey, repo)
 
     return repo
   }

--- a/packages/pinia/src/composable/composable.ts
+++ b/packages/pinia/src/composable/composable.ts
@@ -25,7 +25,8 @@ export function useRattusContext(): RattusContext {
 
 export function useRepository<R extends Repository<InstanceType<M>>, M extends typeof Model = typeof Model>(
   model: M,
+  connection?: string,
 ): UseComputedRepository<R, M> {
-  const repo = useRepositoryForDynamicContext<R, M>(useRattusContext, model)
+  const repo = useRepositoryForDynamicContext<R, M>(useRattusContext, model, connection)
   return computifyUseRepository<R, M>(repo)
 }

--- a/packages/pinia/test/composable.spec.ts
+++ b/packages/pinia/test/composable.spec.ts
@@ -2,7 +2,13 @@ import { describe, expect } from 'vitest'
 import { computed, nextTick } from 'vue'
 import { installRattusORM, useRepository, useRattusContext, PiniaDataProvider } from '../src'
 import { createPinia } from 'pinia'
-import { testContext, testMethodsBound, testMethodsNotRuined, TestUser } from '@rattus-orm/core/utils/testUtils'
+import {
+  testContext,
+  testCustomConnection,
+  testMethodsBound,
+  testMethodsNotRuined,
+  TestUser,
+} from '@rattus-orm/core/utils/testUtils'
 import { renderHookWithContext, renderWithContext } from '@rattus-orm/core/utils/vueTestUtils'
 import { isComputed } from '@rattus-orm/core/utils/vueComposableUtils'
 
@@ -29,6 +35,8 @@ describe('composable: pinia', () => {
     'pinia',
     renderPiniaHook(() => useRepository(TestUser)),
   )
+
+  testCustomConnection('pinia', renderPiniaHook(useRattusContext))
 
   it('useRepository: returns reactive data', async () => {
     const wrapper = renderWithContext({

--- a/packages/react-mobx/src/hooks/useRepository.ts
+++ b/packages/react-mobx/src/hooks/useRepository.ts
@@ -6,6 +6,7 @@ import { useRattusContext } from './useRattusContext'
 
 export function useRepository<R extends Repository<InstanceType<M>>, M extends typeof Model = typeof Model>(
   model: M,
+  connection?: string,
 ): UseRepository<R, M> {
-  return useRepositoryForDynamicContext(useRattusContext, model)
+  return useRepositoryForDynamicContext(useRattusContext, model, connection)
 }

--- a/packages/react-redux/src/hooks/useRepository.ts
+++ b/packages/react-redux/src/hooks/useRepository.ts
@@ -6,6 +6,7 @@ import { useRattusContext } from './useRattusContext'
 
 export function useRepository<R extends Repository<InstanceType<M>>, M extends typeof Model = typeof Model>(
   model: M,
+  connection?: string,
 ): UseRepository<R, M> {
-  return useRepositoryForDynamicContext(useRattusContext, model)
+  return useRepositoryForDynamicContext(useRattusContext, model, connection)
 }

--- a/packages/react-signals/src/hooks/useRepository.ts
+++ b/packages/react-signals/src/hooks/useRepository.ts
@@ -6,6 +6,7 @@ import { useRattusContext } from './useRattusContext'
 
 export function useRepository<R extends Repository<InstanceType<M>>, M extends typeof Model = typeof Model>(
   model: M,
+  connection?: string,
 ): UseRepository<R, M> {
-  return useRepositoryForDynamicContext(useRattusContext, model)
+  return useRepositoryForDynamicContext(useRattusContext, model, connection)
 }

--- a/packages/solidjs/src/hooks/useRepository.ts
+++ b/packages/solidjs/src/hooks/useRepository.ts
@@ -37,8 +37,9 @@ function computed<T>(cb: () => T): Accessor<T> {
 
 export function useRepository<R extends Repository<InstanceType<M>>, M extends typeof Model = typeof Model>(
   model: M,
+  connection?: string,
 ): UseComputedRepository<R, M> {
-  const repo = useRepositoryForDynamicContext(useRattusContext, model)
+  const repo = useRepositoryForDynamicContext(useRattusContext, model, connection)
 
   return {
     ...repo,

--- a/packages/solidjs/test/hooks.spec.tsx
+++ b/packages/solidjs/test/hooks.spec.tsx
@@ -3,11 +3,16 @@
 import '@testing-library/jest-dom/vitest'
 
 import { describe, expect } from 'vitest'
-import { useRepository, RattusProvider } from '../src'
+import { useRepository, RattusProvider, useRattusContext } from '../src'
 import { renderHook } from '@solidjs/testing-library'
 import { renderWithResultAndContext } from './test-utils'
 import { pullRepositoryGettersKeys } from '@rattus-orm/core/utils/integrationsHelpers'
-import { testMethodsBound, testMethodsNotRuined, TestUser } from '@rattus-orm/core/utils/testUtils'
+import {
+  testCustomConnection,
+  testMethodsBound,
+  testMethodsNotRuined,
+  TestUser,
+} from '@rattus-orm/core/utils/testUtils'
 
 const ReactivityTestComponent = () => {
   const { find } = useRepository(TestUser)
@@ -33,6 +38,8 @@ describe('react-mobx hooks: useRepository', () => {
       wrapper: RattusProvider,
     }).result,
   )
+
+  testCustomConnection('Solid', renderHook(useRattusContext, { wrapper: RattusProvider }).result)
 
   it('useRepository returns reactive data', async () => {
     const {

--- a/packages/svelte/src/hooks/useRepository.ts
+++ b/packages/svelte/src/hooks/useRepository.ts
@@ -45,8 +45,9 @@ function computed<R>(cb: () => R, database: Database, modelEntity: string): Svel
 
 export function useRepository<R extends Repository<InstanceType<M>>, M extends typeof Model = typeof Model>(
   model: M,
+  connection?: string,
 ): UseComputedRepository<R, M> {
-  const repo = useRepositoryForDynamicContext(useRattusContext, model)
+  const repo = useRepositoryForDynamicContext(useRattusContext, model, connection)
   const db = useRattusContext().$database
 
   return {

--- a/packages/svelte/test/hooks.spec.ts
+++ b/packages/svelte/test/hooks.spec.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import { renderFunction, renderWithContext } from './test-utils'
-import { useRepository } from '../dist/rattus-orm-svelte-provider'
+import { useRepository, useRattusContext } from '../dist/rattus-orm-svelte-provider'
 import { pullRepositoryGettersKeys } from '@rattus-orm/core/utils/integrationsHelpers'
 import { act } from '@testing-library/svelte'
 import ReactivityTest from './components/ReactivityTest.svelte'
-import { testMethodsBound, testMethodsNotRuined, TestUser } from '@rattus-orm/core/utils/testUtils'
+import {
+  testCustomConnection,
+  testMethodsBound,
+  testMethodsNotRuined,
+  TestUser,
+} from '@rattus-orm/core/utils/testUtils'
 
 describe('svelte: hooks', () => {
   testMethodsBound(
@@ -18,6 +23,8 @@ describe('svelte: hooks', () => {
     'Svelte',
     renderFunction(() => useRepository(TestUser)),
   )
+
+  testCustomConnection('Svelte', renderFunction(useRattusContext))
 
   it('useRepository: returns reactive data', async () => {
     const wrapper = renderWithContext(ReactivityTest)

--- a/packages/vuex/src/composable/composable.ts
+++ b/packages/vuex/src/composable/composable.ts
@@ -19,8 +19,9 @@ export function useRattusContext(injectKey?: InjectionKey<Store<any>>): RattusCo
 
 export function useRepository<R extends Repository<InstanceType<M>>, M extends typeof Model = typeof Model>(
   model: M,
+  connection?: string,
   injectKey?: InjectionKey<Store<any>>,
 ): UseComputedRepository<R, M> {
-  const repo = useRepositoryForDynamicContext<R, M>(() => useRattusContext(injectKey), model)
+  const repo = useRepositoryForDynamicContext<R, M>(() => useRattusContext(injectKey), model, connection)
   return computifyUseRepository<R, M>(repo)
 }

--- a/packages/vuex/test/composable.spec.ts
+++ b/packages/vuex/test/composable.spec.ts
@@ -5,7 +5,13 @@ import { installRattusORM, useRepository, VuexDataProvider } from '../src'
 import { useRattusContext } from '../src'
 import { renderHookWithContext, renderWithContext } from '@rattus-orm/core/utils/vueTestUtils'
 import { isComputed } from '@rattus-orm/core/utils/vueComposableUtils'
-import { testContext, testMethodsBound, testMethodsNotRuined, TestUser } from '@rattus-orm/core/utils/testUtils'
+import {
+  testContext,
+  testMethodsBound,
+  testMethodsNotRuined,
+  TestUser,
+  testCustomConnection,
+} from '@rattus-orm/core/utils/testUtils'
 
 const renderVuexHook = <T>(hook: () => T): T => {
   return renderHookWithContext({
@@ -34,6 +40,8 @@ describe('composable: vuex', () => {
     'vuex',
     renderVuexHook(() => useRepository(TestUser)),
   )
+
+  testCustomConnection('vuex', renderVuexHook(useRattusContext))
 
   it('useRepository: returns reactive data', async () => {
     const wrapper = renderWithContext({


### PR DESCRIPTION
Since now you can easily access other connections via hooks (React, Solid) or composables (Vue). 

For example, React:
```tsx
function App() {
  const context = useRattusContext()
  context.createDatabase('custom-connection')
  
  // works correctly: data from "custom-connection" is returned
  const user = useRepository(User, 'custom-connection')
}
```

Previously it was not possible to pass a second argument. It was possible to obtain a repository for a custom connection only through the `$repo` method of the RattusContext instance.

Works for all integrations.