### PR TITLE
⚙️ Refactor database: dump, restore and DataProvider adjustments

### DIFF
--- a/packages/angular-rxjs/test/rattus-context.service.spec.ts
+++ b/packages/angular-rxjs/test/rattus-context.service.spec.ts
@@ -48,7 +48,7 @@ describe('RattusContextService', () => {
       const service = TestBed.inject(RattusContextService)
 
       expect(service.getDatabase().getConnection()).toEqual('third')
-      expect((service.getDatabase().getDataProvider() as any).provider).toBeInstanceOf(TestDataProvider)
+      expect(service.getDatabase().getDataProvider()).toBeInstanceOf(TestDataProvider)
     })
 
     it('respects custom repositories, they have observe method', () => {

--- a/packages/core/shared-utils/testUtils.ts
+++ b/packages/core/shared-utils/testUtils.ts
@@ -68,7 +68,7 @@ export function testContext(context: any, provider: Constructor<DataProvider>, c
   expect(isUnknownRecord(context.$databases)).toEqual(true)
   expect(context.$databases[connection]).toBeInstanceOf(Database)
   expect(context.$database.getConnection()).toEqual(connection)
-  expect((context.$database.getDataProvider() as any).provider).toBeInstanceOf(provider)
+  expect(context.$database.getDataProvider()).toBeInstanceOf(provider)
 }
 
 export function testMethodsBound<T extends UseRepository<any>>(
@@ -114,7 +114,7 @@ export function testMethodsNotRuined(name: string, useRepo: UseRepository<any>, 
 export function testCustomConnection(name: string, context: RattusContext) {
   it(`${name}: custom connection works`, () => {
     context.$repo(TestUser).save({ id: '333', age: 20 } satisfies RawModel<TestUser>)
-    const dataProvider = (context.$database.getDataProvider() as any).provider
+    const dataProvider = context.$database.getDataProvider()
 
     context.createDatabase('custom30').setDataProvider(dataProvider).start()
     context.$repo(TestUser, 'custom30').save({ id: '333', age: 30 } satisfies RawModel<TestUser>)

--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -99,6 +99,14 @@ export class Database {
   }
 
   /**
+   * Get current DataProvider wrapped in
+   * EventsDataProviderWraper
+   */
+  public getWrappedDataProvider() {
+    return this.dataProvider
+  }
+
+  /**
    * Set the connection.
    *
    * @param {string} connection connection name

--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -1,4 +1,4 @@
-import type { DataProvider, Elements, State } from '@/data/types'
+import type { DataProvider, Elements, SerializedStorage, State } from '@/data/types'
 import type { DatabasePlugin } from '@/database/types'
 import { EventsDataProviderWrapper } from '@/events/events-data-provider-wrapper'
 import type {
@@ -90,10 +90,12 @@ export class Database {
   }
 
   /**
-   * Get current database DataProvider
+   * Get current database DataProvider.
+   * Returns initial DataProvider, not wrapped with
+   * EventsDataProviderWrapper.
    */
   public getDataProvider() {
-    return this.dataProvider
+    return this.dataProvider.getWrappedProvider()
   }
 
   /**
@@ -240,6 +242,26 @@ export class Database {
   }
 
   /**
+   * Export all data from current connection
+   * as JavaScript object
+   */
+  public dump(): SerializedStorage {
+    const connection = this.getConnection()
+    return {
+      [connection]: this.dataProvider.dump()[connection],
+    }
+  }
+
+  /**
+   * Import data into database
+   *
+   * @param {SerializedStorage} data data to import
+   */
+  public restore(data: SerializedStorage) {
+    this.dataProvider.restore(data)
+  }
+
+  /**
    * Register all related models.
    */
   protected registerRelatedModels<M extends Model>(model: M): void {
@@ -268,7 +290,7 @@ export class Database {
   }
 
   /**
-   * Create sub state.
+   * Create sub-state.
    */
   protected createState(): State {
     return {

--- a/packages/core/src/events/events-data-provider-wrapper.ts
+++ b/packages/core/src/events/events-data-provider-wrapper.ts
@@ -101,6 +101,10 @@ export class EventsDataProviderWrapper implements DataProvider {
     }
   }
 
+  public getWrappedProvider(): DataProvider {
+    return this.provider
+  }
+
   protected dispatchVoidEvent<T = string>(event: RattusEvent, param: T, modulePath: ModulePath) {
     this.getListenersForEvent(event).forEach((listener) => listener(param, modulePath))
   }

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -668,7 +668,7 @@ export class Query<M extends Model = Model> {
   }
 
   protected getDataProvider() {
-    return this.database.getDataProvider()
+    return this.database.getWrappedDataProvider()
   }
 
   protected getDatabaseConnection() {

--- a/packages/core/test/context.spec.ts
+++ b/packages/core/test/context.spec.ts
@@ -36,7 +36,7 @@ describe('context.spec.ts', () => {
   })
 
   it('respects custom created database', () => {
-    const db = new Database().setConnection('third')
+    const db = new Database().setConnection('third').setDataProvider(new ObjectDataProvider())
     const context = createRattusContext({ database: db })
 
     expect(context.$database).toEqual(db)

--- a/packages/core/test/database.spec.ts
+++ b/packages/core/test/database.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect } from 'vitest'
+import { Database } from '../src'
+import { ObjectDataProvider } from '../src/object-data-provider'
+import { EventsDataProviderWrapper } from '../src/events/events-data-provider-wrapper'
+import { TestUser } from '../shared-utils/testUtils'
+
+describe('database', () => {
+  it('getDataProvider returns user-set data provider, not wrapped one', () => {
+    const db = new Database().setDataProvider(new ObjectDataProvider()).setConnection('entities').start()
+
+    expect(db.getDataProvider()).toBeInstanceOf(ObjectDataProvider)
+    expect(db.getDataProvider()).not.toBeInstanceOf(EventsDataProviderWrapper)
+  })
+
+  it('dump works correctly', () => {
+    const dp = new ObjectDataProvider()
+
+    const dbOne = new Database().setDataProvider(dp).setConnection('one').start()
+    dbOne.getRepository(TestUser).save({ id: '1', age: 20 })
+
+    const dbTwo = new Database().setDataProvider(dp).setConnection('two').start()
+    dbTwo.getRepository(TestUser).save({ id: '1', age: 30 })
+
+    expect(dbOne.dump()).toStrictEqual({
+      one: {
+        testUser: {
+          data: {
+            '1': {
+              id: '1',
+              age: 20,
+            },
+          },
+        },
+      },
+    })
+
+    expect(dbTwo.dump()).toStrictEqual({
+      two: {
+        testUser: {
+          data: {
+            '1': {
+              id: '1',
+              age: 30,
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('restore works correctly', () => {
+    const dp = new ObjectDataProvider()
+    const dbOne = new Database().setDataProvider(dp).setConnection('one').start()
+
+    dbOne.restore({ one: { testUser: { data: { '1': { id: '1', age: 20 } } } } })
+    expect(dbOne.getRepository(TestUser).find('1')?.$toJson()).toStrictEqual({ id: '1', age: 20 })
+  })
+})

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -14,4 +14,9 @@ export default defineConfig({
       '@core-shared-utils': path.resolve(__dirname, './shared-utils')
     },
   },
+  esbuild: {
+    target: 'es2022',
+    include: /\.(m?[jt]s|[jt]sx)$/,
+    exclude: []
+  }
 })

--- a/packages/plugin-zod-validate/test/rattus-orm-plugin-zod-validate.spec.ts
+++ b/packages/plugin-zod-validate/test/rattus-orm-plugin-zod-validate.spec.ts
@@ -6,12 +6,11 @@ import { ObjectDataProvider } from '@rattus-orm/core/object-data-provider'
 import { z } from 'zod'
 
 export const createDb = (strict: boolean | string[] = true) => {
-  const db = new Database()
+  return new Database()
     .setDataProvider(new ObjectDataProvider())
     .setConnection('entities')
     .use(RattusZodValidationPlugin({ strict }))
-  db.start()
-  return db
+    .start()
 }
 
 type JobType = {


### PR DESCRIPTION
`Database` now has three new methods: 
1. `dump()` - exports all data for current connection as JS object
2. `restore(data)` - imports all data from JS object, modules are created automatically
3. `getWrappedDataProvider()` - returns user's DataProvider wrapped with events layer.

All tests are fixed according to these changes. 