### PR TITLE
⚙️ Feature: new RawModel generic type

### DIFF
--- a/packages/core/src/data/types.ts
+++ b/packages/core/src/data/types.ts
@@ -5,20 +5,11 @@ export type Item<M extends Model = Model> = M | null
 
 export type Collection<M extends Model = Model> = M[]
 
-export type RawModel<
-  T extends Model,
-  PK extends string = 'id',
-  PKV extends string | number | string[] | number[] = string,
-> = Omit<T, keyof Model | RecordKeysByValueType<T, (...args: any) => any>> & { [key in PK]: PKV }
-
-export type RawModelWithRelations<
-  T extends Model,
-  PK extends string = 'id',
-  PKV extends string | number | string[] | number[] = string,
-> = {
-  [key in keyof RawModel<T, PK, PKV>]: RawModel<T, PK, PKV>[key] extends Model
-    ? RawModelWithRelations<RawModel<T, PK, PKV>[key], PK, PKV>
-    : RawModel<T, PK, PKV>[key]
+export type RawModel<T extends Model> = Omit<
+  T,
+  keyof Model | RecordKeysByValueType<T, (...args: any) => any> | RecordKeysByValueType<T, Model>
+> & {
+  [key in RecordKeysByValueType<T, Model>]?: T[key] extends Model ? RawModel<T[key]> : never
 }
 
 export type ModulePath = [connection: string, module: string]

--- a/packages/core/src/model/Model.ts
+++ b/packages/core/src/model/Model.ts
@@ -1,6 +1,6 @@
 import { isUnknownRecord } from '@core-shared-utils/isUnknownRecord'
 
-import type { Collection, Element, Item } from '@/data/types'
+import type { Collection, Element, Item, RawModel } from '@/data/types'
 import type { Type } from '@/model/attributes/types/Type'
 import type { ModelConstructor } from '@/model/types'
 import { assert, isArray, isFunction, isNullish } from '@/support/utils'
@@ -418,23 +418,22 @@ export class Model {
    * Get the serialized model attributes.
    */
   public $getAttributes(): Element {
-    return this.$toJson(this, { relations: false })
+    return this.$toJson({ relations: false })
   }
 
   /**
    * Serialize this model, or the given model, as POJO.
    *
-   * @param {Model} model optional to serialize
    * @param {ModelOptions} options optional options to apply
    */
-  public $toJson(model: Model = this, options: ModelOptions = {}): Element {
-    return Object.entries(model.$fields()).reduce<Element>((result, [key, attr]) => {
+  public $toJson(options: ModelOptions = { relations: true }): RawModel<this> {
+    return Object.entries(this.$fields()).reduce((result, [key, attr]) => {
       result[key] =
-        attr instanceof Relation && (options.relations ?? true)
-          ? this.serializeRelation(model[key])
-          : this.serializeValue(model[key])
+        attr instanceof Relation && options.relations
+          ? this.serializeRelation(this[key])
+          : this.serializeValue(this[key])
       return result
-    }, {})
+    }, {}) as RawModel<this>
   }
 
   /**


### PR DESCRIPTION
`RawModel` generic type allows you to get types of model data without model-specific elements, like methods, internal or added by you. 
`Model.$toJson()` now returns RawModel. 