### PR TITLE
 🔌  Feature/do not require this in attrbutes

### DIFF
--- a/packages/core/src/attributes/common/contracts.ts
+++ b/packages/core/src/attributes/common/contracts.ts
@@ -1,7 +1,12 @@
+import { Attribute } from '@/attributes/common/attribute'
 import type { Model } from '@/model/Model'
+import { ModelConstructor } from '@/model/types'
 
 export type PropertyDecorator = (target: Model, propertyKey: string) => void
 
 export interface TypeOptions {
   nullable?: boolean
 }
+
+export type AttributeFactory<T> = (model: ModelConstructor<any>) => Attribute<T>
+export type ModelAttributeFactory<T> = (...args: any[]) => AttributeFactory<T>

--- a/packages/core/src/attributes/relations/createBelongsToRelation.ts
+++ b/packages/core/src/attributes/relations/createBelongsToRelation.ts
@@ -3,13 +3,13 @@ import type { ModelConstructor } from '@/model/types'
 import { BelongsTo } from './classes/belongs-to'
 
 export const createBelongsToRelation = (
-  modelConstructor: ModelConstructor<any>,
   relatedConstructor: ModelConstructor<any>,
   foreignKey: string,
   ownerKey?: string,
 ) => {
-  const model = modelConstructor.newRawInstance()
-  const related = relatedConstructor.newRawInstance()
-
-  return new BelongsTo(model, related, foreignKey, ownerKey ?? related.$getLocalKey())
+  return (modelConstructor: ModelConstructor<any>) => {
+    const model = modelConstructor.newRawInstance()
+    const related = relatedConstructor.newRawInstance()
+    return new BelongsTo(model, related, foreignKey, ownerKey ?? related.$getLocalKey())
+  }
 }

--- a/packages/core/src/attributes/relations/createBelongsToRelation.ts
+++ b/packages/core/src/attributes/relations/createBelongsToRelation.ts
@@ -3,13 +3,13 @@ import type { ModelConstructor } from '@/model/types'
 import { BelongsTo } from './classes/belongs-to'
 
 export const createBelongsToRelation = (
-  relatedConstructor: ModelConstructor<any>,
+  relatedConstructor: () => ModelConstructor<any>,
   foreignKey: string,
   ownerKey?: string,
 ) => {
   return (modelConstructor: ModelConstructor<any>) => {
     const model = modelConstructor.newRawInstance()
-    const related = relatedConstructor.newRawInstance()
+    const related = relatedConstructor().newRawInstance()
     return new BelongsTo(model, related, foreignKey, ownerKey ?? related.$getLocalKey())
   }
 }

--- a/packages/core/src/attributes/relations/createHasManyByRelation.ts
+++ b/packages/core/src/attributes/relations/createHasManyByRelation.ts
@@ -3,13 +3,13 @@ import type { ModelConstructor } from '@/model/types'
 import { HasManyBy } from './classes/has-many-by'
 
 export const createHasManyByRelation = (
-  relatedConstructor: ModelConstructor<any>,
+  relatedConstructor: () => ModelConstructor<any>,
   foreignKey: string,
   ownerKey?: string,
 ) => {
   return (modelConstructor: ModelConstructor<any>) => {
     const model = modelConstructor.newRawInstance()
-    const related = relatedConstructor.newRawInstance()
+    const related = relatedConstructor().newRawInstance()
     return new HasManyBy(model, related, foreignKey, ownerKey ?? related.$getLocalKey())
   }
 }

--- a/packages/core/src/attributes/relations/createHasManyByRelation.ts
+++ b/packages/core/src/attributes/relations/createHasManyByRelation.ts
@@ -3,13 +3,13 @@ import type { ModelConstructor } from '@/model/types'
 import { HasManyBy } from './classes/has-many-by'
 
 export const createHasManyByRelation = (
-  modelConstructor: ModelConstructor<any>,
   relatedConstructor: ModelConstructor<any>,
   foreignKey: string,
   ownerKey?: string,
 ) => {
-  const model = modelConstructor.newRawInstance()
-  const related = relatedConstructor.newRawInstance()
-
-  return new HasManyBy(model, related, foreignKey, ownerKey ?? related.$getLocalKey())
+  return (modelConstructor: ModelConstructor<any>) => {
+    const model = modelConstructor.newRawInstance()
+    const related = relatedConstructor.newRawInstance()
+    return new HasManyBy(model, related, foreignKey, ownerKey ?? related.$getLocalKey())
+  }
 }

--- a/packages/core/src/attributes/relations/createHasManyRelation.ts
+++ b/packages/core/src/attributes/relations/createHasManyRelation.ts
@@ -3,12 +3,11 @@ import type { ModelConstructor } from '@/model/types'
 import { HasMany } from './classes/has-many'
 
 export const createHasManyRelation = (
-  modelConstructor: ModelConstructor<any>,
   related: () => ModelConstructor<any>,
   foreignKey: string,
   localKey?: string,
 ) => {
-  return () => {
+  return (modelConstructor: ModelConstructor<any>) => {
     const model = modelConstructor.newRawInstance()
     return new HasMany(
       model,

--- a/packages/core/src/attributes/relations/createHasManyRelation.ts
+++ b/packages/core/src/attributes/relations/createHasManyRelation.ts
@@ -4,11 +4,17 @@ import { HasMany } from './classes/has-many'
 
 export const createHasManyRelation = (
   modelConstructor: ModelConstructor<any>,
-  related: ModelConstructor<any>,
+  related: () => ModelConstructor<any>,
   foreignKey: string,
   localKey?: string,
 ) => {
-  const model = modelConstructor.newRawInstance()
-
-  return new HasMany(model, related.newRawInstance(), foreignKey, localKey ?? model.$getLocalKey())
+  return () => {
+    const model = modelConstructor.newRawInstance()
+    return new HasMany(
+      model,
+      related().newRawInstance(),
+      foreignKey,
+      localKey ?? model.$getLocalKey(),
+    )
+  }
 }

--- a/packages/core/src/attributes/relations/createHasOneRelation.ts
+++ b/packages/core/src/attributes/relations/createHasOneRelation.ts
@@ -3,11 +3,17 @@ import type { ModelConstructor } from '@/model/types'
 import { HasOne } from './classes/has-one'
 
 export const createHasOneRelation = (
-  modelConstructor: ModelConstructor<any>,
-  related: ModelConstructor<any>,
+  related: () => ModelConstructor<any>,
   foreignKey: string,
   localKey?: string,
 ) => {
-  const model = modelConstructor.newRawInstance()
-  return new HasOne(model, related.newRawInstance(), foreignKey, localKey ?? model.$getLocalKey())
+  return (modelConstructor: ModelConstructor<any>) => {
+    const model = modelConstructor.newRawInstance()
+    return new HasOne(
+      model,
+      related().newRawInstance(),
+      foreignKey,
+      localKey ?? model.$getLocalKey(),
+    )
+  }
 }

--- a/packages/core/src/attributes/relations/createMorphOneRelation.ts
+++ b/packages/core/src/attributes/relations/createMorphOneRelation.ts
@@ -3,13 +3,19 @@ import type { ModelConstructor } from '@/model/types'
 import { MorphOne } from './classes/morph-one'
 
 export const createMorphOneRelation = (
-  related: ModelConstructor<any>,
+  related: () => ModelConstructor<any>,
   id: string,
   type: string,
   localKey?: string,
 ) => {
   return (modelConstructor: ModelConstructor<any>) => {
     const model = modelConstructor.newRawInstance()
-    return new MorphOne(model, related.newRawInstance(), id, type, localKey ?? model.$getLocalKey())
+    return new MorphOne(
+      model,
+      related().newRawInstance(),
+      id,
+      type,
+      localKey ?? model.$getLocalKey(),
+    )
   }
 }

--- a/packages/core/src/attributes/relations/createMorphOneRelation.ts
+++ b/packages/core/src/attributes/relations/createMorphOneRelation.ts
@@ -3,12 +3,13 @@ import type { ModelConstructor } from '@/model/types'
 import { MorphOne } from './classes/morph-one'
 
 export const createMorphOneRelation = (
-  modelConstructor: ModelConstructor<any>,
   related: ModelConstructor<any>,
   id: string,
   type: string,
   localKey?: string,
 ) => {
-  const model = modelConstructor.newRawInstance()
-  return new MorphOne(model, related.newRawInstance(), id, type, localKey ?? model.$getLocalKey())
+  return (modelConstructor: ModelConstructor<any>) => {
+    const model = modelConstructor.newRawInstance()
+    return new MorphOne(model, related.newRawInstance(), id, type, localKey ?? model.$getLocalKey())
+  }
 }

--- a/packages/core/src/attributes/relations/createMorphToRelation.ts
+++ b/packages/core/src/attributes/relations/createMorphToRelation.ts
@@ -3,18 +3,19 @@ import type { ModelConstructor } from '@/model/types'
 import { MorphTo } from './classes/morph-to'
 
 export const createMorphToRelation = (
-  modelConstructor: ModelConstructor<any>,
-  related: ModelConstructor<any>[],
+  related: () => ModelConstructor<any>[],
   id: string,
   type: string,
   ownerKey = '',
 ) => {
-  const model = modelConstructor.newRawInstance()
-  return new MorphTo(
-    model,
-    related.map((model) => model.newRawInstance()),
-    id,
-    type,
-    ownerKey,
-  )
+  return (modelConstructor: ModelConstructor<any>) => {
+    const model = modelConstructor.newRawInstance()
+    return new MorphTo(
+      model,
+      related().map((model) => model.newRawInstance()),
+      id,
+      type,
+      ownerKey,
+    )
+  }
 }

--- a/packages/core/src/attributes/relations/decorators/BelongsTo.ts
+++ b/packages/core/src/attributes/relations/decorators/BelongsTo.ts
@@ -12,6 +12,6 @@ export function BelongsTo(
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
-    self.setRegistry(propertyKey, createBelongsToRelation(related(), foreignKey, ownerKey))
+    self.setRegistry(propertyKey, createBelongsToRelation(related, foreignKey, ownerKey))
   }
 }

--- a/packages/core/src/attributes/relations/decorators/BelongsTo.ts
+++ b/packages/core/src/attributes/relations/decorators/BelongsTo.ts
@@ -12,9 +12,6 @@ export function BelongsTo(
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
-
-    self.setRegistry(propertyKey, () =>
-      createBelongsToRelation(self, related(), foreignKey, ownerKey),
-    )
+    self.setRegistry(propertyKey, createBelongsToRelation(related(), foreignKey, ownerKey))
   }
 }

--- a/packages/core/src/attributes/relations/decorators/HasMany.ts
+++ b/packages/core/src/attributes/relations/decorators/HasMany.ts
@@ -12,9 +12,6 @@ export function HasMany(
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
-
-    self.setRegistry(propertyKey, () =>
-      createHasManyRelation(self, related(), foreignKey, localKey),
-    )
+    self.setRegistry(propertyKey, createHasManyRelation(self, related, foreignKey, localKey))
   }
 }

--- a/packages/core/src/attributes/relations/decorators/HasMany.ts
+++ b/packages/core/src/attributes/relations/decorators/HasMany.ts
@@ -12,6 +12,6 @@ export function HasMany(
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
-    self.setRegistry(propertyKey, createHasManyRelation(self, related, foreignKey, localKey))
+    self.setRegistry(propertyKey, createHasManyRelation(related, foreignKey, localKey))
   }
 }

--- a/packages/core/src/attributes/relations/decorators/HasManyBy.ts
+++ b/packages/core/src/attributes/relations/decorators/HasManyBy.ts
@@ -13,8 +13,6 @@ export function HasManyBy(
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, () =>
-      createHasManyByRelation(self, related(), foreignKey, ownerKey),
-    )
+    self.setRegistry(propertyKey, createHasManyByRelation(related(), foreignKey, ownerKey))
   }
 }

--- a/packages/core/src/attributes/relations/decorators/HasManyBy.ts
+++ b/packages/core/src/attributes/relations/decorators/HasManyBy.ts
@@ -12,7 +12,6 @@ export function HasManyBy(
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
-
-    self.setRegistry(propertyKey, createHasManyByRelation(related(), foreignKey, ownerKey))
+    self.setRegistry(propertyKey, createHasManyByRelation(related, foreignKey, ownerKey))
   }
 }

--- a/packages/core/src/attributes/relations/decorators/HasOne.ts
+++ b/packages/core/src/attributes/relations/decorators/HasOne.ts
@@ -12,7 +12,6 @@ export function HasOne(
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
-
-    self.setRegistry(propertyKey, () => createHasOneRelation(self, related(), foreignKey, localKey))
+    self.setRegistry(propertyKey, createHasOneRelation(related, foreignKey, localKey))
   }
 }

--- a/packages/core/src/attributes/relations/decorators/MorphOne.ts
+++ b/packages/core/src/attributes/relations/decorators/MorphOne.ts
@@ -13,7 +13,6 @@ export function MorphOne(
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
-
-    self.setRegistry(propertyKey, () => createMorphOneRelation(self, related(), id, type, localKey))
+    self.setRegistry(propertyKey, createMorphOneRelation(related(), id, type, localKey))
   }
 }

--- a/packages/core/src/attributes/relations/decorators/MorphOne.ts
+++ b/packages/core/src/attributes/relations/decorators/MorphOne.ts
@@ -13,6 +13,6 @@ export function MorphOne(
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
-    self.setRegistry(propertyKey, createMorphOneRelation(related(), id, type, localKey))
+    self.setRegistry(propertyKey, createMorphOneRelation(related, id, type, localKey))
   }
 }

--- a/packages/core/src/attributes/relations/decorators/MorphTo.ts
+++ b/packages/core/src/attributes/relations/decorators/MorphTo.ts
@@ -13,7 +13,6 @@ export function MorphTo(
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
-
-    self.setRegistry(propertyKey, () => createMorphToRelation(self, related(), id, type, ownerKey))
+    self.setRegistry(propertyKey, createMorphToRelation(related, id, type, ownerKey))
   }
 }

--- a/packages/core/src/attributes/types/createAttrField.ts
+++ b/packages/core/src/attributes/types/createAttrField.ts
@@ -1,7 +1,12 @@
 import type { ModelConstructor } from '@/model/types'
 
+import { AttributeFactory } from '@/attributes/common/contracts'
 import { Attr } from './classes/Attr'
 
 export const createAttrField = (model: ModelConstructor<any>, value?: any) => {
   return new Attr(model.newRawInstance(), value)
+}
+
+export function createAttrFieldAF(value?: any): AttributeFactory<Attr> {
+  return (model: ModelConstructor<any>) => new Attr(model.newRawInstance(), value)
 }

--- a/packages/core/src/attributes/types/createAttrField.ts
+++ b/packages/core/src/attributes/types/createAttrField.ts
@@ -3,10 +3,6 @@ import type { ModelConstructor } from '@/model/types'
 import { AttributeFactory } from '@/attributes/common/contracts'
 import { Attr } from './classes/Attr'
 
-export const createAttrField = (model: ModelConstructor<any>, value?: any) => {
-  return new Attr(model.newRawInstance(), value)
-}
-
-export function createAttrFieldAF(value?: any): AttributeFactory<Attr> {
+export function createAttrField(value?: any): AttributeFactory<Attr> {
   return (model: ModelConstructor<any>) => new Attr(model.newRawInstance(), value)
 }

--- a/packages/core/src/attributes/types/createBooleanField.ts
+++ b/packages/core/src/attributes/types/createBooleanField.ts
@@ -1,6 +1,7 @@
 import type { ModelConstructor } from '@/model/types'
 
 import { AttributeFactory } from '@/attributes/common/contracts'
+import { nullableTypeFactory } from '@/attributes/types/utils'
 import { Boolean as BooleanAttr } from './classes/Boolean'
 
 export const createBooleanField = (model: ModelConstructor<any>, value: boolean | null) => {
@@ -11,11 +12,5 @@ export function createBooleanFieldAF(
   value: boolean | null,
   nullable = false,
 ): AttributeFactory<boolean | null> {
-  return (model: ModelConstructor<any>) => {
-    const attr = new BooleanAttr(model.newRawInstance(), value)
-    if (nullable) {
-      attr.nullable()
-    }
-    return attr
-  }
+  return (model: ModelConstructor<any>) => nullableTypeFactory(BooleanAttr, model, nullable, value)
 }

--- a/packages/core/src/attributes/types/createBooleanField.ts
+++ b/packages/core/src/attributes/types/createBooleanField.ts
@@ -1,7 +1,21 @@
 import type { ModelConstructor } from '@/model/types'
 
-import { Boolean } from './classes/Boolean'
+import { AttributeFactory } from '@/attributes/common/contracts'
+import { Boolean as BooleanAttr } from './classes/Boolean'
 
 export const createBooleanField = (model: ModelConstructor<any>, value: boolean | null) => {
-  return new Boolean(model.newRawInstance(), value)
+  return new BooleanAttr(model.newRawInstance(), value)
+}
+
+export function createBooleanFieldAF(
+  value: boolean | null,
+  nullable = false,
+): AttributeFactory<boolean | null> {
+  return (model: ModelConstructor<any>) => {
+    const attr = new BooleanAttr(model.newRawInstance(), value)
+    if (nullable) {
+      attr.nullable()
+    }
+    return attr
+  }
 }

--- a/packages/core/src/attributes/types/createBooleanField.ts
+++ b/packages/core/src/attributes/types/createBooleanField.ts
@@ -4,11 +4,7 @@ import { AttributeFactory } from '@/attributes/common/contracts'
 import { nullableTypeFactory } from '@/attributes/types/utils'
 import { Boolean as BooleanAttr } from './classes/Boolean'
 
-export const createBooleanField = (model: ModelConstructor<any>, value: boolean | null) => {
-  return new BooleanAttr(model.newRawInstance(), value)
-}
-
-export function createBooleanFieldAF(
+export function createBooleanField(
   value: boolean | null,
   nullable = false,
 ): AttributeFactory<boolean | null> {

--- a/packages/core/src/attributes/types/createDateField.ts
+++ b/packages/core/src/attributes/types/createDateField.ts
@@ -1,6 +1,7 @@
 import type { ModelConstructor } from '@/model/types'
 
 import { AttributeFactory } from '@/attributes/common/contracts'
+import { nullableTypeFactory } from '@/attributes/types/utils'
 import { DateAttr } from './classes/DateAttr'
 
 export const createDateField = (model: ModelConstructor<any>, value: Date | null) => {
@@ -11,11 +12,5 @@ export function createDateFieldAF(
   value: Date | null,
   nullable = false,
 ): AttributeFactory<Date | null> {
-  return (model: ModelConstructor<any>) => {
-    const attr = new DateAttr(model.newRawInstance(), value)
-    if (nullable) {
-      attr.nullable()
-    }
-    return attr
-  }
+  return (model: ModelConstructor<any>) => nullableTypeFactory(DateAttr, model, nullable, value)
 }

--- a/packages/core/src/attributes/types/createDateField.ts
+++ b/packages/core/src/attributes/types/createDateField.ts
@@ -4,11 +4,7 @@ import { AttributeFactory } from '@/attributes/common/contracts'
 import { nullableTypeFactory } from '@/attributes/types/utils'
 import { DateAttr } from './classes/DateAttr'
 
-export const createDateField = (model: ModelConstructor<any>, value: Date | null) => {
-  return new DateAttr(model.newRawInstance(), value)
-}
-
-export function createDateFieldAF(
+export function createDateField(
   value: Date | null,
   nullable = false,
 ): AttributeFactory<Date | null> {

--- a/packages/core/src/attributes/types/createDateField.ts
+++ b/packages/core/src/attributes/types/createDateField.ts
@@ -1,7 +1,21 @@
 import type { ModelConstructor } from '@/model/types'
 
+import { AttributeFactory } from '@/attributes/common/contracts'
 import { DateAttr } from './classes/DateAttr'
 
 export const createDateField = (model: ModelConstructor<any>, value: Date | null) => {
   return new DateAttr(model.newRawInstance(), value)
+}
+
+export function createDateFieldAF(
+  value: Date | null,
+  nullable = false,
+): AttributeFactory<Date | null> {
+  return (model: ModelConstructor<any>) => {
+    const attr = new DateAttr(model.newRawInstance(), value)
+    if (nullable) {
+      attr.nullable()
+    }
+    return attr
+  }
 }

--- a/packages/core/src/attributes/types/createNumberField.ts
+++ b/packages/core/src/attributes/types/createNumberField.ts
@@ -4,11 +4,7 @@ import { AttributeFactory } from '@/attributes/common/contracts'
 import { nullableTypeFactory } from '@/attributes/types/utils'
 import { Number } from './classes/Number'
 
-export const createNumberField = (model: ModelConstructor<any>, value: number | null) => {
-  return new Number(model.newRawInstance(), value)
-}
-
-export function createNumberFieldAF(
+export function createNumberField(
   value: number | null,
   nullable = false,
 ): AttributeFactory<number | null> {

--- a/packages/core/src/attributes/types/createNumberField.ts
+++ b/packages/core/src/attributes/types/createNumberField.ts
@@ -1,6 +1,7 @@
 import type { ModelConstructor } from '@/model/types'
 
 import { AttributeFactory } from '@/attributes/common/contracts'
+import { nullableTypeFactory } from '@/attributes/types/utils'
 import { Number } from './classes/Number'
 
 export const createNumberField = (model: ModelConstructor<any>, value: number | null) => {
@@ -11,11 +12,5 @@ export function createNumberFieldAF(
   value: number | null,
   nullable = false,
 ): AttributeFactory<number | null> {
-  return (model: ModelConstructor<any>) => {
-    const attr = new Number(model.newRawInstance(), value)
-    if (nullable) {
-      attr.nullable()
-    }
-    return attr
-  }
+  return (model: ModelConstructor<any>) => nullableTypeFactory(Number, model, nullable, value)
 }

--- a/packages/core/src/attributes/types/createNumberField.ts
+++ b/packages/core/src/attributes/types/createNumberField.ts
@@ -1,7 +1,21 @@
 import type { ModelConstructor } from '@/model/types'
 
+import { AttributeFactory } from '@/attributes/common/contracts'
 import { Number } from './classes/Number'
 
 export const createNumberField = (model: ModelConstructor<any>, value: number | null) => {
   return new Number(model.newRawInstance(), value)
+}
+
+export function createNumberFieldAF(
+  value: number | null,
+  nullable = false,
+): AttributeFactory<number | null> {
+  return (model: ModelConstructor<any>) => {
+    const attr = new Number(model.newRawInstance(), value)
+    if (nullable) {
+      attr.nullable()
+    }
+    return attr
+  }
 }

--- a/packages/core/src/attributes/types/createStringField.ts
+++ b/packages/core/src/attributes/types/createStringField.ts
@@ -1,6 +1,7 @@
 import type { ModelConstructor } from '@/model/types'
 
 import { AttributeFactory } from '@/attributes/common/contracts'
+import { nullableTypeFactory } from '@/attributes/types/utils'
 import { String } from './classes/String'
 
 export const createStringField = (model: ModelConstructor<any>, value: string | null) => {
@@ -11,11 +12,5 @@ export function createStringFieldAF(
   value: string | null,
   nullable = false,
 ): AttributeFactory<string | null> {
-  return (model: ModelConstructor<any>) => {
-    const attr = new String(model.newRawInstance(), value)
-    if (nullable) {
-      attr.nullable()
-    }
-    return attr
-  }
+  return (model: ModelConstructor<any>) => nullableTypeFactory(String, model, nullable, value)
 }

--- a/packages/core/src/attributes/types/createStringField.ts
+++ b/packages/core/src/attributes/types/createStringField.ts
@@ -1,7 +1,21 @@
 import type { ModelConstructor } from '@/model/types'
 
+import { AttributeFactory } from '@/attributes/common/contracts'
 import { String } from './classes/String'
 
 export const createStringField = (model: ModelConstructor<any>, value: string | null) => {
   return new String(model.newRawInstance(), value)
+}
+
+export function createStringFieldAF(
+  value: string | null,
+  nullable = false,
+): AttributeFactory<string | null> {
+  return (model: ModelConstructor<any>) => {
+    const attr = new String(model.newRawInstance(), value)
+    if (nullable) {
+      attr.nullable()
+    }
+    return attr
+  }
 }

--- a/packages/core/src/attributes/types/createStringField.ts
+++ b/packages/core/src/attributes/types/createStringField.ts
@@ -4,11 +4,7 @@ import { AttributeFactory } from '@/attributes/common/contracts'
 import { nullableTypeFactory } from '@/attributes/types/utils'
 import { String } from './classes/String'
 
-export const createStringField = (model: ModelConstructor<any>, value: string | null) => {
-  return new String(model.newRawInstance(), value)
-}
-
-export function createStringFieldAF(
+export function createStringField(
   value: string | null,
   nullable = false,
 ): AttributeFactory<string | null> {

--- a/packages/core/src/attributes/types/createUidField.ts
+++ b/packages/core/src/attributes/types/createUidField.ts
@@ -1,7 +1,12 @@
 import type { ModelConstructor } from '@/model/types'
 
+import { AttributeFactory } from '@/attributes/common/contracts'
 import { Uid } from './classes/Uid'
 
 export const createUidField = (model: ModelConstructor<any>, value?: any) => {
   return new Uid(model.newRawInstance(), value)
+}
+
+export function createUidFieldAF(value?: any): AttributeFactory<any> {
+  return (model: ModelConstructor<any>) => new Uid(model.newRawInstance(), value)
 }

--- a/packages/core/src/attributes/types/createUidField.ts
+++ b/packages/core/src/attributes/types/createUidField.ts
@@ -3,10 +3,6 @@ import type { ModelConstructor } from '@/model/types'
 import { AttributeFactory } from '@/attributes/common/contracts'
 import { Uid } from './classes/Uid'
 
-export const createUidField = (model: ModelConstructor<any>, value?: any) => {
-  return new Uid(model.newRawInstance(), value)
-}
-
-export function createUidFieldAF(value?: any): AttributeFactory<any> {
+export function createUidField(value?: any): AttributeFactory<any> {
   return (model: ModelConstructor<any>) => new Uid(model.newRawInstance(), value)
 }

--- a/packages/core/src/attributes/types/decorators/AttrField.ts
+++ b/packages/core/src/attributes/types/decorators/AttrField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator } from '../../common/contracts'
-import { createAttrFieldAF } from '../createAttrField'
+import { createAttrField } from '../createAttrField'
 
 /**
  * Create an Attr attribute property decorator.
@@ -8,6 +8,6 @@ export function AttrField(value?: any): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, createAttrFieldAF(value))
+    self.setRegistry(propertyKey, createAttrField(value))
   }
 }

--- a/packages/core/src/attributes/types/decorators/AttrField.ts
+++ b/packages/core/src/attributes/types/decorators/AttrField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator } from '../../common/contracts'
-import { createAttrField } from '../createAttrField'
+import { createAttrFieldAF } from '../createAttrField'
 
 /**
  * Create an Attr attribute property decorator.
@@ -8,6 +8,6 @@ export function AttrField(value?: any): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, () => createAttrField(self, value))
+    self.setRegistry(propertyKey, createAttrFieldAF(value))
   }
 }

--- a/packages/core/src/attributes/types/decorators/BooleanField.ts
+++ b/packages/core/src/attributes/types/decorators/BooleanField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator, TypeOptions } from '../../common/contracts'
-import { createBooleanField } from '../createBooleanField'
+import { createBooleanFieldAF } from '../createBooleanField'
 
 /**
  * Create a Boolean attribute property decorator.
@@ -8,13 +8,6 @@ export function BooleanField(value: boolean | null, options: TypeOptions = {}): 
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, () => {
-      const attr = createBooleanField(self, value)
-      if (options.nullable) {
-        attr.nullable()
-      }
-
-      return attr
-    })
+    self.setRegistry(propertyKey, createBooleanFieldAF(value, options.nullable))
   }
 }

--- a/packages/core/src/attributes/types/decorators/BooleanField.ts
+++ b/packages/core/src/attributes/types/decorators/BooleanField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator, TypeOptions } from '../../common/contracts'
-import { createBooleanFieldAF } from '../createBooleanField'
+import { createBooleanField } from '../createBooleanField'
 
 /**
  * Create a Boolean attribute property decorator.
@@ -8,6 +8,6 @@ export function BooleanField(value: boolean | null, options: TypeOptions = {}): 
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, createBooleanFieldAF(value, options.nullable))
+    self.setRegistry(propertyKey, createBooleanField(value, options.nullable))
   }
 }

--- a/packages/core/src/attributes/types/decorators/DateField.ts
+++ b/packages/core/src/attributes/types/decorators/DateField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator, TypeOptions } from '../../common/contracts'
-import { createDateField } from '../createDateField'
+import { createDateFieldAF } from '../createDateField'
 
 /**
  * Create a Number attribute property decorator.
@@ -11,14 +11,9 @@ export function DateField(
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, () => {
-      const attr = createDateField(self, value ? new Date(value) : null)
-
-      if (options.nullable) {
-        attr.nullable()
-      }
-
-      return attr
-    })
+    self.setRegistry(
+      propertyKey,
+      createDateFieldAF(value ? new Date(value) : null, options.nullable),
+    )
   }
 }

--- a/packages/core/src/attributes/types/decorators/DateField.ts
+++ b/packages/core/src/attributes/types/decorators/DateField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator, TypeOptions } from '../../common/contracts'
-import { createDateFieldAF } from '../createDateField'
+import { createDateField } from '../createDateField'
 
 /**
  * Create a Number attribute property decorator.
@@ -11,9 +11,6 @@ export function DateField(
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(
-      propertyKey,
-      createDateFieldAF(value ? new Date(value) : null, options.nullable),
-    )
+    self.setRegistry(propertyKey, createDateField(value ? new Date(value) : null, options.nullable))
   }
 }

--- a/packages/core/src/attributes/types/decorators/NumberField.ts
+++ b/packages/core/src/attributes/types/decorators/NumberField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator, TypeOptions } from '../../common/contracts'
-import { createNumberFieldAF } from '../createNumberField'
+import { createNumberField } from '../createNumberField'
 
 /**
  * Create a Number attribute property decorator.
@@ -8,6 +8,6 @@ export function NumberField(value: number | null, options: TypeOptions = {}): Pr
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, createNumberFieldAF(value, options.nullable))
+    self.setRegistry(propertyKey, createNumberField(value, options.nullable))
   }
 }

--- a/packages/core/src/attributes/types/decorators/NumberField.ts
+++ b/packages/core/src/attributes/types/decorators/NumberField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator, TypeOptions } from '../../common/contracts'
-import { createNumberField } from '../createNumberField'
+import { createNumberFieldAF } from '../createNumberField'
 
 /**
  * Create a Number attribute property decorator.
@@ -8,14 +8,6 @@ export function NumberField(value: number | null, options: TypeOptions = {}): Pr
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, () => {
-      const attr = createNumberField(self, value)
-
-      if (options.nullable) {
-        attr.nullable()
-      }
-
-      return attr
-    })
+    self.setRegistry(propertyKey, createNumberFieldAF(value, options.nullable))
   }
 }

--- a/packages/core/src/attributes/types/decorators/StringField.ts
+++ b/packages/core/src/attributes/types/decorators/StringField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator, TypeOptions } from '../../common/contracts'
-import { createStringField } from '../createStringField'
+import { createStringFieldAF } from '../createStringField'
 
 /**
  * Create a String attribute property decorator.
@@ -8,14 +8,6 @@ export function StringField(value: string | null, options: TypeOptions = {}): Pr
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, () => {
-      const attr = createStringField(self, value)
-
-      if (options.nullable) {
-        attr.nullable()
-      }
-
-      return attr
-    })
+    self.setRegistry(propertyKey, createStringFieldAF(value, options.nullable))
   }
 }

--- a/packages/core/src/attributes/types/decorators/StringField.ts
+++ b/packages/core/src/attributes/types/decorators/StringField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator, TypeOptions } from '../../common/contracts'
-import { createStringFieldAF } from '../createStringField'
+import { createStringField } from '../createStringField'
 
 /**
  * Create a String attribute property decorator.
@@ -8,6 +8,6 @@ export function StringField(value: string | null, options: TypeOptions = {}): Pr
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, createStringFieldAF(value, options.nullable))
+    self.setRegistry(propertyKey, createStringField(value, options.nullable))
   }
 }

--- a/packages/core/src/attributes/types/decorators/UidField.ts
+++ b/packages/core/src/attributes/types/decorators/UidField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator } from '../../common/contracts'
-import { createUidField } from '../createUidField'
+import { createUidFieldAF } from '../createUidField'
 
 /**
  * Create a Uid attribute property decorator.
@@ -8,6 +8,6 @@ export function UidField(): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, () => createUidField(self))
+    self.setRegistry(propertyKey, createUidFieldAF())
   }
 }

--- a/packages/core/src/attributes/types/decorators/UidField.ts
+++ b/packages/core/src/attributes/types/decorators/UidField.ts
@@ -1,5 +1,5 @@
 import type { PropertyDecorator } from '../../common/contracts'
-import { createUidFieldAF } from '../createUidField'
+import { createUidField } from '../createUidField'
 
 /**
  * Create a Uid attribute property decorator.
@@ -8,6 +8,6 @@ export function UidField(): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
 
-    self.setRegistry(propertyKey, createUidFieldAF())
+    self.setRegistry(propertyKey, createUidField())
   }
 }

--- a/packages/core/src/attributes/types/utils.ts
+++ b/packages/core/src/attributes/types/utils.ts
@@ -1,0 +1,16 @@
+import { ModelConstructor } from '@/model/types'
+import { Constructor } from '@/types'
+import { Type } from './classes/Type'
+
+export function nullableTypeFactory<T extends Type<any>>(
+  AttrC: Constructor<T>,
+  model: ModelConstructor<any>,
+  nullable: boolean | undefined,
+  value: any,
+) {
+  const attr = new AttrC(model.newRawInstance(), value)
+  if (nullable) {
+    attr.nullable()
+  }
+  return attr
+}

--- a/packages/core/src/model/Model.ts
+++ b/packages/core/src/model/Model.ts
@@ -7,13 +7,14 @@ import type { MorphTo } from '@/attributes/relations/classes/morph-to'
 import type { Relation } from '@/attributes/relations/classes/relation'
 import type { Collection, Element, Item, RawModel } from '@/data/types'
 import type { ModelConstructor } from '@/model/types'
-import { assert, isArray, isFunction, isNullish } from '@/support/utils'
+import { assert, isArray, isNullish } from '@/support/utils'
 import type { Constructor } from '@/types'
 
 export type ModelFields = Record<string, Attribute<unknown>>
 export type ModelSchemas = Record<string, ModelFields>
 export type ModelRegistries = Record<string, ModelRegistry>
 export type ModelRegistry = Record<string, AttributeFactory<unknown>>
+export type ModelFieldsDefinition = Record<string, AttributeFactory<unknown>>
 
 export interface ModelOptions {
   fill?: boolean
@@ -67,7 +68,7 @@ export class Model {
   /**
    * Create a new model fields definition.
    */
-  public static fields(): ModelFields {
+  public static fields(): ModelFieldsDefinition {
     return {}
   }
 
@@ -138,7 +139,7 @@ export class Model {
       ...this.fields(),
       ...this.registries[this.entity],
     })) {
-      this.schemas[this.entity][key] = isFunction(attribute) ? attribute(this) : attribute
+      this.schemas[this.entity][key] = attribute(this)
     }
   }
 

--- a/packages/core/src/model/Model.ts
+++ b/packages/core/src/model/Model.ts
@@ -1,6 +1,7 @@
 import { isUnknownRecord } from '@core-shared-utils/isUnknownRecord'
 
 import { isKindOf, isRelation, morphToKind } from '@/attributes/common/const'
+import { AttributeFactory } from '@/attributes/common/contracts'
 import type { Attribute, Type } from '@/attributes/field-types'
 import type { MorphTo } from '@/attributes/relations/classes/morph-to'
 import type { Relation } from '@/attributes/relations/classes/relation'
@@ -12,7 +13,7 @@ import type { Constructor } from '@/types'
 export type ModelFields = Record<string, Attribute<unknown>>
 export type ModelSchemas = Record<string, ModelFields>
 export type ModelRegistries = Record<string, ModelRegistry>
-export type ModelRegistry = Record<string, () => Attribute<unknown>>
+export type ModelRegistry = Record<string, AttributeFactory<unknown>>
 
 export interface ModelOptions {
   fill?: boolean
@@ -79,7 +80,7 @@ export class Model {
   public static setRegistry<M extends typeof Model>(
     this: M,
     key: string,
-    attribute: () => Attribute<unknown>,
+    attribute: AttributeFactory<unknown>,
   ): M {
     this.registries[this.entity] = {
       ...(this.registries[this.entity] ?? {}),
@@ -137,7 +138,7 @@ export class Model {
       ...this.fields(),
       ...this.registries[this.entity],
     })) {
-      this.schemas[this.entity][key] = isFunction(attribute) ? attribute() : attribute
+      this.schemas[this.entity][key] = isFunction(attribute) ? attribute(this) : attribute
     }
   }
 

--- a/packages/core/test/model/Model_Fields.spec.ts
+++ b/packages/core/test/model/Model_Fields.spec.ts
@@ -1,10 +1,10 @@
 import { Model } from '@/model/Model'
 import { expect } from 'vitest'
-import { createAttrField } from '../../src/attributes/types/createAttrField'
-import { createBooleanField } from '../../src/attributes/types/createBooleanField'
-import { createDateField } from '../../src/attributes/types/createDateField'
-import { createNumberField } from '../../src/attributes/types/createNumberField'
-import { createStringField } from '../../src/attributes/types/createStringField'
+import { createAttrFieldAF } from '../../src/attributes/types/createAttrField'
+import { createBooleanFieldAF } from '../../src/attributes/types/createBooleanField'
+import { createDateFieldAF } from '../../src/attributes/types/createDateField'
+import { createNumberFieldAF } from '../../src/attributes/types/createNumberField'
+import { createStringFieldAF } from '../../src/attributes/types/createStringField'
 
 describe('unit/model/Model_Fields', () => {
   it('can define model fields as a static function', () => {
@@ -13,11 +13,11 @@ describe('unit/model/Model_Fields', () => {
 
       static fields() {
         return {
-          id: createAttrField(this, null),
-          str: createStringField(this, ''),
-          num: createNumberField(this, 0),
-          bool: createBooleanField(this, false),
-          date: createDateField(this, new Date()),
+          id: createAttrFieldAF(null),
+          str: createStringFieldAF(''),
+          num: createNumberFieldAF(0),
+          bool: createBooleanFieldAF(false),
+          date: createDateFieldAF(new Date()),
         }
       }
 

--- a/packages/core/test/model/Model_Fields.spec.ts
+++ b/packages/core/test/model/Model_Fields.spec.ts
@@ -1,10 +1,10 @@
 import { Model } from '@/model/Model'
 import { expect } from 'vitest'
-import { createAttrFieldAF } from '../../src/attributes/types/createAttrField'
-import { createBooleanFieldAF } from '../../src/attributes/types/createBooleanField'
-import { createDateFieldAF } from '../../src/attributes/types/createDateField'
-import { createNumberFieldAF } from '../../src/attributes/types/createNumberField'
-import { createStringFieldAF } from '../../src/attributes/types/createStringField'
+import { createAttrField } from '../../src/attributes/types/createAttrField'
+import { createBooleanField } from '../../src/attributes/types/createBooleanField'
+import { createDateField } from '../../src/attributes/types/createDateField'
+import { createNumberField } from '../../src/attributes/types/createNumberField'
+import { createStringField } from '../../src/attributes/types/createStringField'
 
 describe('unit/model/Model_Fields', () => {
   it('can define model fields as a static function', () => {
@@ -13,11 +13,11 @@ describe('unit/model/Model_Fields', () => {
 
       static fields() {
         return {
-          id: createAttrFieldAF(null),
-          str: createStringFieldAF(''),
-          num: createNumberFieldAF(0),
-          bool: createBooleanFieldAF(false),
-          date: createDateFieldAF(new Date()),
+          id: createAttrField(null),
+          str: createStringField(''),
+          num: createNumberField(0),
+          bool: createBooleanField(false),
+          date: createDateField(new Date()),
         }
       }
 

--- a/packages/docs/docs/docs-core/models.mdx
+++ b/packages/docs/docs/docs-core/models.mdx
@@ -51,9 +51,9 @@ from the `Model` class:
 
             static fields () {
                 return {
-                    id: createUidField(this),
-                    name: createStringField(this, ''),
-                    age: createNumberField(this, 0)
+                    id: createUidField(),
+                    name: createStringField(''),
+                    age: createNumberField(0)
                 }
             }
         }

--- a/packages/docs/i18n/ru/docusaurus-plugin-content-docs/current/docs-core/models.mdx
+++ b/packages/docs/i18n/ru/docusaurus-plugin-content-docs/current/docs-core/models.mdx
@@ -51,9 +51,9 @@ TypeScript и декораторами.
 
             static fields () {
                 return {
-                    id: createUidField(this),
-                    name: createStringField(this, ''),
-                    age: createNumberField(this, 0)
+                    id: createUidField(),
+                    name: createStringField(''),
+                    age: createNumberField(0)
                 }
             }
         }

--- a/test/feature/relations-non-decorators/belongs_to_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_retrieve.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/belongs_to_retrieve', () => {
     
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, '')
+        id: createAttrField(),
+        name: createStringField('')
       }
     }
   }
@@ -22,9 +22,9 @@ describe('feature/relations-non-decorators/belongs_to_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        title: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        title: createStringField(''),
         author: createBelongsToRelation(this, User, 'userId'),
       }
     }

--- a/test/feature/relations-non-decorators/belongs_to_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_retrieve.spec.ts
@@ -7,11 +7,11 @@ import { Model } from '@/index'
 describe('feature/relations-non-decorators/belongs_to_retrieve', () => {
   class User extends Model {
     static entity = 'users'
-    
+
     public static fields() {
       return {
         id: createAttrField(),
-        name: createStringField('')
+        name: createStringField(''),
       }
     }
   }
@@ -19,13 +19,12 @@ describe('feature/relations-non-decorators/belongs_to_retrieve', () => {
   class Post extends Model {
     static entity = 'posts'
 
-
     public static fields() {
       return {
         id: createAttrField(),
         userId: createAttrField(),
         title: createStringField(''),
-        author: createBelongsToRelation(this, User, 'userId'),
+        author: createBelongsToRelation(User, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/belongs_to_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_retrieve.spec.ts
@@ -24,7 +24,7 @@ describe('feature/relations-non-decorators/belongs_to_retrieve', () => {
         id: createAttrField(),
         userId: createAttrField(),
         title: createStringField(''),
-        author: createBelongsToRelation(User, 'userId'),
+        author: createBelongsToRelation(() => User, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/belongs_to_save.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_save.spec.ts
@@ -27,7 +27,7 @@ describe('feature/relations-non-decorators/belongs_to_save', () => {
         id: createAttrField(),
         userId: createAttrField(),
         title: createStringField(''),
-        author: createBelongsToRelation(User, 'userId'),
+        author: createBelongsToRelation(() => User, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/belongs_to_save.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_save.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/belongs_to_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
       }
     }
 
@@ -25,9 +25,9 @@ describe('feature/relations-non-decorators/belongs_to_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        title: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        title: createStringField(''),
         author: createBelongsToRelation(this, User, 'userId'),
       }
     }

--- a/test/feature/relations-non-decorators/belongs_to_save.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_save.spec.ts
@@ -22,13 +22,12 @@ describe('feature/relations-non-decorators/belongs_to_save', () => {
   class Post extends Model {
     static entity = 'posts'
 
-
     public static fields() {
       return {
         id: createAttrField(),
         userId: createAttrField(),
         title: createStringField(''),
-        author: createBelongsToRelation(this, User, 'userId'),
+        author: createBelongsToRelation(User, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/belongs_to_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_save_custom_key.spec.ts
@@ -17,8 +17,8 @@ describe('feature/relations-non-decorators/belongs_to_save_custome_key', () => {
 
       public static fields() {
         return {
-          userId: createAttrField(this),
-          name: createStringField(this, ''),
+          userId: createAttrField(),
+          name: createStringField(''),
         }
       }
 
@@ -31,9 +31,9 @@ describe('feature/relations-non-decorators/belongs_to_save_custome_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          title: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          title: createStringField(''),
           author: createBelongsToRelation(this, User, 'userId'),
         }
       }
@@ -68,9 +68,9 @@ describe('feature/relations-non-decorators/belongs_to_save_custome_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          name: createStringField(''),
         }
       }
 
@@ -84,9 +84,9 @@ describe('feature/relations-non-decorators/belongs_to_save_custome_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          title: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          title: createStringField(''),
           author: createBelongsToRelation(this, User, 'userId', 'userId'),
         }
       }

--- a/test/feature/relations-non-decorators/belongs_to_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_save_custom_key.spec.ts
@@ -34,7 +34,7 @@ describe('feature/relations-non-decorators/belongs_to_save_custome_key', () => {
           id: createAttrField(),
           userId: createAttrField(),
           title: createStringField(''),
-          author: createBelongsToRelation(this, User, 'userId'),
+          author: createBelongsToRelation(User, 'userId'),
         }
       }
 
@@ -87,7 +87,7 @@ describe('feature/relations-non-decorators/belongs_to_save_custome_key', () => {
           id: createAttrField(),
           userId: createAttrField(),
           title: createStringField(''),
-          author: createBelongsToRelation(this, User, 'userId', 'userId'),
+          author: createBelongsToRelation(User, 'userId', 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/belongs_to_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_save_custom_key.spec.ts
@@ -34,7 +34,7 @@ describe('feature/relations-non-decorators/belongs_to_save_custome_key', () => {
           id: createAttrField(),
           userId: createAttrField(),
           title: createStringField(''),
-          author: createBelongsToRelation(User, 'userId'),
+          author: createBelongsToRelation(() => User, 'userId'),
         }
       }
 
@@ -87,7 +87,7 @@ describe('feature/relations-non-decorators/belongs_to_save_custome_key', () => {
           id: createAttrField(),
           userId: createAttrField(),
           title: createStringField(''),
-          author: createBelongsToRelation(User, 'userId', 'userId'),
+          author: createBelongsToRelation(() => User, 'userId', 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/belongs_to_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_save_uid.spec.ts
@@ -9,7 +9,6 @@ describe('feature/relations-non-decorators/belongs_to_save_uid', () => {
   beforeEach(() => {
     Model.clearRegistries()
   })
-  
 
   it('inserts "belongs to" relation with parent having "uid" field as the primary key', () => {
     class User extends Model {
@@ -34,7 +33,7 @@ describe('feature/relations-non-decorators/belongs_to_save_uid', () => {
           id: createUidField(),
           userId: createAttrField(),
           title: createStringField(''),
-          author: createBelongsToRelation(this, User, 'userId'),
+          author: createBelongsToRelation(User, 'userId'),
         }
       }
 
@@ -86,7 +85,7 @@ describe('feature/relations-non-decorators/belongs_to_save_uid', () => {
           id: createUidField(),
           userId: createAttrField(),
           title: createStringField(''),
-          author: createBelongsToRelation(this, User, 'userId'),
+          author: createBelongsToRelation(User, 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/belongs_to_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_save_uid.spec.ts
@@ -33,7 +33,7 @@ describe('feature/relations-non-decorators/belongs_to_save_uid', () => {
           id: createUidField(),
           userId: createAttrField(),
           title: createStringField(''),
-          author: createBelongsToRelation(User, 'userId'),
+          author: createBelongsToRelation(() => User, 'userId'),
         }
       }
 
@@ -85,7 +85,7 @@ describe('feature/relations-non-decorators/belongs_to_save_uid', () => {
           id: createUidField(),
           userId: createAttrField(),
           title: createStringField(''),
-          author: createBelongsToRelation(User, 'userId'),
+          author: createBelongsToRelation(() => User, 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/belongs_to_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/belongs_to_save_uid.spec.ts
@@ -17,8 +17,8 @@ describe('feature/relations-non-decorators/belongs_to_save_uid', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createAttrField(),
+          name: createStringField(''),
         }
       }
 
@@ -31,9 +31,9 @@ describe('feature/relations-non-decorators/belongs_to_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          userId: createAttrField(this),
-          title: createStringField(this, ''),
+          id: createUidField(),
+          userId: createAttrField(),
+          title: createStringField(''),
           author: createBelongsToRelation(this, User, 'userId'),
         }
       }
@@ -69,8 +69,8 @@ describe('feature/relations-non-decorators/belongs_to_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
         }
       }
 
@@ -83,9 +83,9 @@ describe('feature/relations-non-decorators/belongs_to_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          userId: createAttrField(this),
-          title: createStringField(this, ''),
+          id: createUidField(),
+          userId: createAttrField(),
+          title: createStringField(''),
           author: createBelongsToRelation(this, User, 'userId'),
         }
       }

--- a/test/feature/relations-non-decorators/constraints/constraints.spec.ts
+++ b/test/feature/relations-non-decorators/constraints/constraints.spec.ts
@@ -11,8 +11,8 @@ describe('feature/relations-non-decorators/constraints/constraints', () => {
 
     static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         phone: createHasOneRelation(this, Phone, 'userId'),
       }
     }
@@ -27,9 +27,9 @@ describe('feature/relations-non-decorators/constraints/constraints', () => {
 
     static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        number: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        number: createStringField(''),
         type: createHasOneRelation(this, Type, 'phoneId'),
       }
     }
@@ -45,9 +45,9 @@ describe('feature/relations-non-decorators/constraints/constraints', () => {
 
     static fields() {
       return {
-        id: createAttrField(this),
-        phoneId: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        phoneId: createAttrField(),
+        name: createStringField(''),
       }
     }
 

--- a/test/feature/relations-non-decorators/constraints/constraints.spec.ts
+++ b/test/feature/relations-non-decorators/constraints/constraints.spec.ts
@@ -13,7 +13,7 @@ describe('feature/relations-non-decorators/constraints/constraints', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        phone: createHasOneRelation(this, Phone, 'userId'),
+        phone: createHasOneRelation(() => Phone, 'userId'),
       }
     }
 
@@ -30,7 +30,7 @@ describe('feature/relations-non-decorators/constraints/constraints', () => {
         id: createAttrField(),
         userId: createAttrField(),
         number: createStringField(''),
-        type: createHasOneRelation(this, Type, 'phoneId'),
+        type: createHasOneRelation(() => Type, 'phoneId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/eager_loads/eager_loads_all.spec.ts
+++ b/test/feature/relations-non-decorators/eager_loads/eager_loads_all.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/eager_loads_all', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
       }
     }
 
@@ -24,9 +24,9 @@ describe('feature/relations-non-decorators/eager_loads_all', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        title: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        title: createStringField(''),
         author: createBelongsToRelation(this, User, 'userId'),
         comments: createHasManyRelation(this, Comment, 'postId'),
       }
@@ -44,9 +44,9 @@ describe('feature/relations-non-decorators/eager_loads_all', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        postId: createAttrField(this),
-        content: createStringField(this, ''),
+        id: createAttrField(),
+        postId: createAttrField(),
+        content: createStringField(''),
       }
     }
 

--- a/test/feature/relations-non-decorators/eager_loads/eager_loads_all.spec.ts
+++ b/test/feature/relations-non-decorators/eager_loads/eager_loads_all.spec.ts
@@ -27,8 +27,8 @@ describe('feature/relations-non-decorators/eager_loads_all', () => {
         id: createAttrField(),
         userId: createAttrField(),
         title: createStringField(''),
-        author: createBelongsToRelation(this, User, 'userId'),
-        comments: createHasManyRelation(this, Comment, 'postId'),
+        author: createBelongsToRelation(() => User, 'userId'),
+        comments: createHasManyRelation(() => Comment, 'postId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/eager_loads/eager_loads_recursive.spec.ts
+++ b/test/feature/relations-non-decorators/eager_loads/eager_loads_recursive.spec.ts
@@ -12,7 +12,7 @@ describe('feature/relations-non-decorators/eager_loads_recursive', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        phone: createHasOneRelation(this, Phone, 'userId'),
+        phone: createHasOneRelation(() => Phone, 'userId'),
       }
     }
 
@@ -29,7 +29,7 @@ describe('feature/relations-non-decorators/eager_loads_recursive', () => {
         id: createAttrField(),
         userId: createAttrField(),
         number: createStringField(''),
-        user: createBelongsToRelation(this, User, 'userId'),
+        user: createBelongsToRelation(() => User, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/eager_loads/eager_loads_recursive.spec.ts
+++ b/test/feature/relations-non-decorators/eager_loads/eager_loads_recursive.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/eager_loads_recursive', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         phone: createHasOneRelation(this, Phone, 'userId'),
       }
     }
@@ -26,9 +26,9 @@ describe('feature/relations-non-decorators/eager_loads_recursive', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        number: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        number: createStringField(''),
         user: createBelongsToRelation(this, User, 'userId'),
       }
     }

--- a/test/feature/relations-non-decorators/has_many_by_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_retrieve.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/has_many_by_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
       }
     }
 
@@ -24,9 +24,9 @@ describe('feature/relations-non-decorators/has_many_by_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        nodeIds: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        nodeIds: createAttrField(),
+        name: createStringField(''),
         nodes: createHasManyByRelation(this, Node, 'nodeIds'),
       }
     }

--- a/test/feature/relations-non-decorators/has_many_by_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_retrieve.spec.ts
@@ -27,7 +27,7 @@ describe('feature/relations-non-decorators/has_many_by_retrieve', () => {
         id: createAttrField(),
         nodeIds: createAttrField(),
         name: createStringField(''),
-        nodes: createHasManyByRelation(this, Node, 'nodeIds'),
+        nodes: createHasManyByRelation(Node, 'nodeIds'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_by_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_retrieve.spec.ts
@@ -27,7 +27,7 @@ describe('feature/relations-non-decorators/has_many_by_retrieve', () => {
         id: createAttrField(),
         nodeIds: createAttrField(),
         name: createStringField(''),
-        nodes: createHasManyByRelation(Node, 'nodeIds'),
+        nodes: createHasManyByRelation(() => Node, 'nodeIds'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_by_save.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_save.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/has_many_by_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
       }
     }
 
@@ -24,9 +24,9 @@ describe('feature/relations-non-decorators/has_many_by_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        nodeIds: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        nodeIds: createAttrField(),
+        name: createStringField(''),
         nodes: createHasManyByRelation(this, Node, 'nodeIds'),
       }
     }

--- a/test/feature/relations-non-decorators/has_many_by_save.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_save.spec.ts
@@ -27,7 +27,7 @@ describe('feature/relations-non-decorators/has_many_by_save', () => {
         id: createAttrField(),
         nodeIds: createAttrField(),
         name: createStringField(''),
-        nodes: createHasManyByRelation(this, Node, 'nodeIds'),
+        nodes: createHasManyByRelation(Node, 'nodeIds'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_by_save.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_save.spec.ts
@@ -27,7 +27,7 @@ describe('feature/relations-non-decorators/has_many_by_save', () => {
         id: createAttrField(),
         nodeIds: createAttrField(),
         name: createStringField(''),
-        nodes: createHasManyByRelation(Node, 'nodeIds'),
+        nodes: createHasManyByRelation(() => Node, 'nodeIds'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_by_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_save_custom_key.spec.ts
@@ -34,7 +34,7 @@ describe('feature/relations-non-decorators/has_many_by_save_custom_key', () => {
           clusterId: createAttrField(),
           nodeIds: createAttrField(),
           name: createStringField(''),
-          nodes: createHasManyByRelation(Node, 'nodeIds'),
+          nodes: createHasManyByRelation(() => Node, 'nodeIds'),
         }
       }
 
@@ -91,7 +91,7 @@ describe('feature/relations-non-decorators/has_many_by_save_custom_key', () => {
           id: createAttrField(),
           nodeIds: createAttrField(),
           name: createStringField(''),
-          nodes: createHasManyByRelation(Node, 'nodeIds', 'nodeId'),
+          nodes: createHasManyByRelation(() => Node, 'nodeIds', 'nodeId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_many_by_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_save_custom_key.spec.ts
@@ -15,8 +15,8 @@ describe('feature/relations-non-decorators/has_many_by_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createAttrField(),
+          name: createStringField(''),
         }
       }
 
@@ -31,9 +31,9 @@ describe('feature/relations-non-decorators/has_many_by_save_custom_key', () => {
 
       public static fields() {
         return {
-          clusterId: createAttrField(this),
-          nodeIds: createAttrField(this),
-          name: createStringField(this, ''),
+          clusterId: createAttrField(),
+          nodeIds: createAttrField(),
+          name: createStringField(''),
           nodes: createHasManyByRelation(this, Node, 'nodeIds'),
         }
       }
@@ -72,9 +72,9 @@ describe('feature/relations-non-decorators/has_many_by_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          nodeId: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createAttrField(),
+          nodeId: createAttrField(),
+          name: createStringField(''),
         }
       }
 
@@ -88,9 +88,9 @@ describe('feature/relations-non-decorators/has_many_by_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          nodeIds: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createAttrField(),
+          nodeIds: createAttrField(),
+          name: createStringField(''),
           nodes: createHasManyByRelation(this, Node, 'nodeIds', 'nodeId'),
         }
       }

--- a/test/feature/relations-non-decorators/has_many_by_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_save_custom_key.spec.ts
@@ -34,7 +34,7 @@ describe('feature/relations-non-decorators/has_many_by_save_custom_key', () => {
           clusterId: createAttrField(),
           nodeIds: createAttrField(),
           name: createStringField(''),
-          nodes: createHasManyByRelation(this, Node, 'nodeIds'),
+          nodes: createHasManyByRelation(Node, 'nodeIds'),
         }
       }
 
@@ -91,7 +91,7 @@ describe('feature/relations-non-decorators/has_many_by_save_custom_key', () => {
           id: createAttrField(),
           nodeIds: createAttrField(),
           name: createStringField(''),
-          nodes: createHasManyByRelation(this, Node, 'nodeIds', 'nodeId'),
+          nodes: createHasManyByRelation(Node, 'nodeIds', 'nodeId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_many_by_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_save_uid.spec.ts
@@ -33,7 +33,7 @@ describe('feature/relations-non-decorators/has_many_by_insert_uid', () => {
           id: createUidField(),
           nodeIds: createAttrField(),
           name: createStringField(''),
-          nodes: createHasManyByRelation(Node, 'nodeIds'),
+          nodes: createHasManyByRelation(() => Node, 'nodeIds'),
         }
       }
 
@@ -89,7 +89,7 @@ describe('feature/relations-non-decorators/has_many_by_insert_uid', () => {
           id: createUidField(),
           nodeIds: createAttrField(),
           name: createStringField(''),
-          nodes: createHasManyByRelation(Node, 'nodeIds'),
+          nodes: createHasManyByRelation(() => Node, 'nodeIds'),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_many_by_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_save_uid.spec.ts
@@ -33,7 +33,7 @@ describe('feature/relations-non-decorators/has_many_by_insert_uid', () => {
           id: createUidField(),
           nodeIds: createAttrField(),
           name: createStringField(''),
-          nodes: createHasManyByRelation(this, Node, 'nodeIds'),
+          nodes: createHasManyByRelation(Node, 'nodeIds'),
         }
       }
 
@@ -70,7 +70,6 @@ describe('feature/relations-non-decorators/has_many_by_insert_uid', () => {
     class Node extends Model {
       static entity = 'nodes'
 
-
       public static fields() {
         return {
           id: createUidField(),
@@ -90,7 +89,7 @@ describe('feature/relations-non-decorators/has_many_by_insert_uid', () => {
           id: createUidField(),
           nodeIds: createAttrField(),
           name: createStringField(''),
-          nodes: createHasManyByRelation(this, Node, 'nodeIds'),
+          nodes: createHasManyByRelation(Node, 'nodeIds'),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_many_by_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_by_save_uid.spec.ts
@@ -16,8 +16,8 @@ describe('feature/relations-non-decorators/has_many_by_insert_uid', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createAttrField(),
+          name: createStringField(''),
         }
       }
 
@@ -30,9 +30,9 @@ describe('feature/relations-non-decorators/has_many_by_insert_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          nodeIds: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          nodeIds: createAttrField(),
+          name: createStringField(''),
           nodes: createHasManyByRelation(this, Node, 'nodeIds'),
         }
       }
@@ -73,8 +73,8 @@ describe('feature/relations-non-decorators/has_many_by_insert_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
         }
       }
 
@@ -87,9 +87,9 @@ describe('feature/relations-non-decorators/has_many_by_insert_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          nodeIds: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          nodeIds: createAttrField(),
+          name: createStringField(''),
           nodes: createHasManyByRelation(this, Node, 'nodeIds'),
         }
       }

--- a/test/feature/relations-non-decorators/has_many_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_retrieve.spec.ts
@@ -12,7 +12,7 @@ describe('feature/relations-non-decorators/has_many_retrieve', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        posts: createHasManyRelation(this, () => Post, 'userId'),
+        posts: createHasManyRelation(() => Post, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_retrieve.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/has_many_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         posts: createHasManyRelation(this, Post, 'userId'),
       }
     }
@@ -26,9 +26,9 @@ describe('feature/relations-non-decorators/has_many_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        title: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        title: createStringField(''),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_retrieve.spec.ts
@@ -12,7 +12,7 @@ describe('feature/relations-non-decorators/has_many_retrieve', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        posts: createHasManyRelation(this, Post, 'userId'),
+        posts: createHasManyRelation(this, () => Post, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_save.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_save.spec.ts
@@ -12,7 +12,7 @@ describe('feature/relations-non-decorators/has_many_save', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        posts: createHasManyRelation(this, () => Post, 'userId'),
+        posts: createHasManyRelation(() => Post, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_save.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_save.spec.ts
@@ -12,7 +12,7 @@ describe('feature/relations-non-decorators/has_many_save', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        posts: createHasManyRelation(this, Post, 'userId'),
+        posts: createHasManyRelation(this, () => Post, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_save.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_save.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/has_many_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         posts: createHasManyRelation(this, Post, 'userId'),
       }
     }
@@ -26,9 +26,9 @@ describe('feature/relations-non-decorators/has_many_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        title: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        title: createStringField(''),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_many_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_save_custom_key.spec.ts
@@ -19,7 +19,7 @@ describe('feature/relations-non-decorators/has_many_save_custom_key', () => {
         return {
           userId: createAttrField(),
           name: createStringField(''),
-          posts: createHasManyRelation(this, Post, 'userId'),
+          posts: createHasManyRelation(this, () => Post, 'userId'),
         }
       }
 
@@ -75,7 +75,7 @@ describe('feature/relations-non-decorators/has_many_save_custom_key', () => {
           id: createAttrField(),
           userId: createAttrField(),
           name: createStringField(''),
-          posts: createHasManyRelation(this, Post, 'userId', 'userId'),
+          posts: createHasManyRelation(this, () => Post, 'userId', 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_many_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_save_custom_key.spec.ts
@@ -17,8 +17,8 @@ describe('feature/relations-non-decorators/has_many_save_custom_key', () => {
 
       public static fields() {
         return {
-          userId: createAttrField(this),
-          name: createStringField(this, ''),
+          userId: createAttrField(),
+          name: createStringField(''),
           posts: createHasManyRelation(this, Post, 'userId'),
         }
       }
@@ -33,9 +33,9 @@ describe('feature/relations-non-decorators/has_many_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          title: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          title: createStringField(''),
         }
       }
 
@@ -72,9 +72,9 @@ describe('feature/relations-non-decorators/has_many_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          name: createStringField(''),
           posts: createHasManyRelation(this, Post, 'userId', 'userId'),
         }
       }
@@ -90,9 +90,9 @@ describe('feature/relations-non-decorators/has_many_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          title: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          title: createStringField(''),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_many_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_save_custom_key.spec.ts
@@ -19,7 +19,7 @@ describe('feature/relations-non-decorators/has_many_save_custom_key', () => {
         return {
           userId: createAttrField(),
           name: createStringField(''),
-          posts: createHasManyRelation(this, () => Post, 'userId'),
+          posts: createHasManyRelation(() => Post, 'userId'),
         }
       }
 
@@ -75,7 +75,7 @@ describe('feature/relations-non-decorators/has_many_save_custom_key', () => {
           id: createAttrField(),
           userId: createAttrField(),
           name: createStringField(''),
-          posts: createHasManyRelation(this, () => Post, 'userId', 'userId'),
+          posts: createHasManyRelation(() => Post, 'userId', 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_many_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_save_uid.spec.ts
@@ -1,11 +1,7 @@
 import { assertState, createStore } from '@func-test/utils/Helpers'
 
 import { createHasManyRelation } from '@/attributes/field-relations'
-import {
-  createAttrField,
-  createStringField,
-  createUidField,
-} from '@/attributes/field-types'
+import { createAttrField, createStringField, createUidField } from '@/attributes/field-types'
 import { Model } from '@/index'
 import { mockUid } from '@func-test/utils/mock-uid'
 
@@ -22,7 +18,7 @@ describe('feature/relations-non-decorators/has_many_insert_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          posts: createHasManyRelation(this, Post, 'userId'),
+          posts: createHasManyRelation(this, () => Post, 'userId'),
         }
       }
 
@@ -74,12 +70,11 @@ describe('feature/relations-non-decorators/has_many_insert_uid', () => {
     class User extends Model {
       static entity = 'users'
 
-
       public static fields() {
         return {
           id: createUidField(),
           name: createStringField(''),
-          posts: createHasManyRelation(this, Post, 'userId'),
+          posts: createHasManyRelation(this, () => Post, 'userId'),
         }
       }
 
@@ -127,4 +122,3 @@ describe('feature/relations-non-decorators/has_many_insert_uid', () => {
     })
   })
 })
-

--- a/test/feature/relations-non-decorators/has_many_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_save_uid.spec.ts
@@ -18,7 +18,7 @@ describe('feature/relations-non-decorators/has_many_insert_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          posts: createHasManyRelation(this, () => Post, 'userId'),
+          posts: createHasManyRelation(() => Post, 'userId'),
         }
       }
 
@@ -74,7 +74,7 @@ describe('feature/relations-non-decorators/has_many_insert_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          posts: createHasManyRelation(this, () => Post, 'userId'),
+          posts: createHasManyRelation(() => Post, 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_many_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/has_many_save_uid.spec.ts
@@ -20,8 +20,8 @@ describe('feature/relations-non-decorators/has_many_insert_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
           posts: createHasManyRelation(this, Post, 'userId'),
         }
       }
@@ -36,9 +36,9 @@ describe('feature/relations-non-decorators/has_many_insert_uid', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          title: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          title: createStringField(''),
         }
       }
 
@@ -77,8 +77,8 @@ describe('feature/relations-non-decorators/has_many_insert_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
           posts: createHasManyRelation(this, Post, 'userId'),
         }
       }
@@ -93,9 +93,9 @@ describe('feature/relations-non-decorators/has_many_insert_uid', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createUidField(this),
-          title: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createUidField(),
+          title: createStringField(''),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_one_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/has_one_retrieve.spec.ts
@@ -12,7 +12,7 @@ describe('feature/relations-non-decorators/has_one_retrieve', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        phone: createHasOneRelation(this, Phone, 'userId'),
+        phone: createHasOneRelation(() => Phone, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_one_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/has_one_retrieve.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/has_one_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         phone: createHasOneRelation(this, Phone, 'userId'),
       }
     }
@@ -26,9 +26,9 @@ describe('feature/relations-non-decorators/has_one_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        number: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        number: createStringField(''),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_one_save.spec.ts
+++ b/test/feature/relations-non-decorators/has_one_save.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/has_one_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         phone: createHasOneRelation(this, Phone, 'userId'),
       }
     }
@@ -26,9 +26,9 @@ describe('feature/relations-non-decorators/has_one_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        number: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        number: createStringField(''),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_one_save.spec.ts
+++ b/test/feature/relations-non-decorators/has_one_save.spec.ts
@@ -12,7 +12,7 @@ describe('feature/relations-non-decorators/has_one_save', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        phone: createHasOneRelation(this, Phone, 'userId'),
+        phone: createHasOneRelation(() => Phone, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/has_one_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/has_one_save_custom_key.spec.ts
@@ -19,7 +19,7 @@ describe('feature/relations-non-decorators/has_one_save_custom_key', () => {
         return {
           userId: createAttrField(),
           name: createStringField(''),
-          phone: createHasOneRelation(this, Phone, 'userId'),
+          phone: createHasOneRelation(() => Phone, 'userId'),
         }
       }
 
@@ -74,7 +74,7 @@ describe('feature/relations-non-decorators/has_one_save_custom_key', () => {
           id: createAttrField(),
           userId: createAttrField(),
           name: createStringField(''),
-          phone: createHasOneRelation(this, Phone, 'userId', 'userId'),
+          phone: createHasOneRelation(() => Phone, 'userId', 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_one_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/has_one_save_custom_key.spec.ts
@@ -17,8 +17,8 @@ describe('feature/relations-non-decorators/has_one_save_custom_key', () => {
 
       public static fields() {
         return {
-          userId: createAttrField(this),
-          name: createStringField(this, ''),
+          userId: createAttrField(),
+          name: createStringField(''),
           phone: createHasOneRelation(this, Phone, 'userId'),
         }
       }
@@ -33,9 +33,9 @@ describe('feature/relations-non-decorators/has_one_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          number: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          number: createStringField(''),
         }
       }
 
@@ -71,9 +71,9 @@ describe('feature/relations-non-decorators/has_one_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          name: createStringField(''),
           phone: createHasOneRelation(this, Phone, 'userId', 'userId'),
         }
       }
@@ -89,9 +89,9 @@ describe('feature/relations-non-decorators/has_one_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          number: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          number: createStringField(''),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_one_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/has_one_save_uid.spec.ts
@@ -16,8 +16,8 @@ describe('feature/relations-non-decorators/has_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
           phone: createHasOneRelation(this, Phone, 'userId'),
         }
       }
@@ -32,9 +32,9 @@ describe('feature/relations-non-decorators/has_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this),
-          userId: createAttrField(this),
-          number: createStringField(this, ''),
+          id: createAttrField(),
+          userId: createAttrField(),
+          number: createStringField(''),
         }
       }
 
@@ -71,8 +71,8 @@ describe('feature/relations-non-decorators/has_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
           phone: createHasOneRelation(this, Phone, 'userId'),
         }
       }
@@ -87,9 +87,9 @@ describe('feature/relations-non-decorators/has_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          userId: createUidField(this),
-          number: createStringField(this, ''),
+          id: createUidField(),
+          userId: createUidField(),
+          number: createStringField(''),
         }
       }
 
@@ -125,8 +125,8 @@ describe('feature/relations-non-decorators/has_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
           phone: createHasOneRelation(this, Phone, 'userId'),
         }
       }
@@ -143,8 +143,8 @@ describe('feature/relations-non-decorators/has_one_save_uid', () => {
 
       public static fields() {
         return {
-          userId: createUidField(this),
-          number: createStringField(this, ''),
+          userId: createUidField(),
+          number: createStringField(''),
         }
       }
 

--- a/test/feature/relations-non-decorators/has_one_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/has_one_save_uid.spec.ts
@@ -18,7 +18,7 @@ describe('feature/relations-non-decorators/has_one_save_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          phone: createHasOneRelation(this, Phone, 'userId'),
+          phone: createHasOneRelation(() => Phone, 'userId'),
         }
       }
 
@@ -73,7 +73,7 @@ describe('feature/relations-non-decorators/has_one_save_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          phone: createHasOneRelation(this, Phone, 'userId'),
+          phone: createHasOneRelation(() => Phone, 'userId'),
         }
       }
 
@@ -127,7 +127,7 @@ describe('feature/relations-non-decorators/has_one_save_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          phone: createHasOneRelation(this, Phone, 'userId'),
+          phone: createHasOneRelation(() => Phone, 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/lazy_loads/lazy_eager_load.spec.ts
+++ b/test/feature/relations-non-decorators/lazy_loads/lazy_eager_load.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/lazy_loads/lazy_eager_load', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         posts: createHasManyRelation(this, Post, 'userId'),
       }
     }
@@ -26,9 +26,9 @@ describe('feature/relations-non-decorators/lazy_loads/lazy_eager_load', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        title: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        title: createStringField(''),
       }
     }
 

--- a/test/feature/relations-non-decorators/lazy_loads/lazy_eager_load.spec.ts
+++ b/test/feature/relations-non-decorators/lazy_loads/lazy_eager_load.spec.ts
@@ -12,7 +12,7 @@ describe('feature/relations-non-decorators/lazy_loads/lazy_eager_load', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        posts: createHasManyRelation(this, Post, 'userId'),
+        posts: createHasManyRelation(() => Post, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/mitigations/_fixtures/circular_relations_phone.ts
+++ b/test/feature/relations-non-decorators/mitigations/_fixtures/circular_relations_phone.ts
@@ -9,8 +9,8 @@ export default class Phone extends Model {
 
   static fields() {
     return {
-      id: createAttrField(this),
-      userId: createAttrField(this),
+      id: createAttrField(),
+      userId: createAttrField(),
       author: createBelongsToRelation(this, User, 'userId'),
     }
   }

--- a/test/feature/relations-non-decorators/mitigations/_fixtures/circular_relations_phone.ts
+++ b/test/feature/relations-non-decorators/mitigations/_fixtures/circular_relations_phone.ts
@@ -11,7 +11,7 @@ export default class Phone extends Model {
     return {
       id: createAttrField(),
       userId: createAttrField(),
-      author: createBelongsToRelation(this, User, 'userId'),
+      author: createBelongsToRelation(() => User, 'userId'),
     }
   }
 

--- a/test/feature/relations-non-decorators/mitigations/_fixtures/circular_relations_user.ts
+++ b/test/feature/relations-non-decorators/mitigations/_fixtures/circular_relations_user.ts
@@ -9,7 +9,7 @@ export default class User extends Model {
 
   public static fields() {
     return {
-      id: createAttrField(this),
+      id: createAttrField(),
       phone: createHasOneRelation(this, Phone, 'userId'),
     }
   }

--- a/test/feature/relations-non-decorators/mitigations/_fixtures/circular_relations_user.ts
+++ b/test/feature/relations-non-decorators/mitigations/_fixtures/circular_relations_user.ts
@@ -10,7 +10,7 @@ export default class User extends Model {
   public static fields() {
     return {
       id: createAttrField(),
-      phone: createHasOneRelation(this, Phone, 'userId'),
+      phone: createHasOneRelation(() => Phone, 'userId'),
     }
   }
 

--- a/test/feature/relations-non-decorators/morph_one_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_retrieve.spec.ts
@@ -30,7 +30,7 @@ describe('feature/relations-non-decorators/morph_one_retrieve', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
+        image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
       }
     }
 
@@ -46,7 +46,7 @@ describe('feature/relations-non-decorators/morph_one_retrieve', () => {
       return {
         id: createAttrField(),
         title: createStringField(''),
-        image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
+        image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
       }
     }
 

--- a/test/feature/relations-non-decorators/morph_one_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_retrieve.spec.ts
@@ -10,10 +10,10 @@ describe('feature/relations-non-decorators/morph_one_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        url: createStringField(this, ''),
-        imageableId: createAttrField(this),
-        imageableType: createStringField(this, ''),
+        id: createAttrField(),
+        url: createStringField(''),
+        imageableId: createAttrField(),
+        imageableType: createStringField(''),
       }
     }
 
@@ -28,8 +28,8 @@ describe('feature/relations-non-decorators/morph_one_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
       }
     }
@@ -44,8 +44,8 @@ describe('feature/relations-non-decorators/morph_one_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        title: createStringField(this, ''),
+        id: createAttrField(),
+        title: createStringField(''),
         image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
       }
     }

--- a/test/feature/relations-non-decorators/morph_one_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_retrieve.spec.ts
@@ -30,7 +30,7 @@ describe('feature/relations-non-decorators/morph_one_retrieve', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
+        image: createMorphOneRelation(() => Image, 'imageableId', 'imageableType'),
       }
     }
 
@@ -46,7 +46,7 @@ describe('feature/relations-non-decorators/morph_one_retrieve', () => {
       return {
         id: createAttrField(),
         title: createStringField(''),
-        image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
+        image: createMorphOneRelation(() => Image, 'imageableId', 'imageableType'),
       }
     }
 

--- a/test/feature/relations-non-decorators/morph_one_save.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_save.spec.ts
@@ -10,10 +10,10 @@ describe('feature/relations-non-decorators/morph_one_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        url: createStringField(this, ''),
-        imageableId: createAttrField(this),
-        imageableType: createStringField(this, ''),
+        id: createAttrField(),
+        url: createStringField(''),
+        imageableId: createAttrField(),
+        imageableType: createStringField(''),
       }
     }
 
@@ -28,8 +28,8 @@ describe('feature/relations-non-decorators/morph_one_save', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
       }
     }

--- a/test/feature/relations-non-decorators/morph_one_save.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_save.spec.ts
@@ -30,7 +30,7 @@ describe('feature/relations-non-decorators/morph_one_save', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
+        image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
       }
     }
 

--- a/test/feature/relations-non-decorators/morph_one_save.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_save.spec.ts
@@ -30,7 +30,7 @@ describe('feature/relations-non-decorators/morph_one_save', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
+        image: createMorphOneRelation(() => Image, 'imageableId', 'imageableType'),
       }
     }
 

--- a/test/feature/relations-non-decorators/morph_one_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_save_custom_key.spec.ts
@@ -15,10 +15,10 @@ describe('feature/relations-non-decorators/morph_one_save_custom_key', () => {
 
       static fields() {
         return {
-          id: createNumberField(this, 0),
-          url: createStringField(this, ''),
-          imageableId: createStringField(this, ''),
-          imageableType: createStringField(this, ''),
+          id: createNumberField(0),
+          url: createStringField(''),
+          imageableId: createStringField(''),
+          imageableType: createStringField(''),
         }
       }
 
@@ -35,8 +35,8 @@ describe('feature/relations-non-decorators/morph_one_save_custom_key', () => {
 
       static fields() {
         return {
-          userId: createStringField(this, ''),
-          name: createStringField(this, ''),
+          userId: createStringField(''),
+          name: createStringField(''),
           image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
         }
       }
@@ -79,10 +79,10 @@ describe('feature/relations-non-decorators/morph_one_save_custom_key', () => {
 
       static fields() {
         return {
-          id: createNumberField(this, 0),
-          url: createStringField(this, ''),
-          imageableId: createStringField(this, ''),
-          imageableType: createStringField(this, ''),
+          id: createNumberField(0),
+          url: createStringField(''),
+          imageableId: createStringField(''),
+          imageableType: createStringField(''),
         }
       }
 
@@ -97,9 +97,9 @@ describe('feature/relations-non-decorators/morph_one_save_custom_key', () => {
 
       static fields() {
         return {
-          id: createNumberField(this, 0),
-          userId: createStringField(this, ''),
-          name: createStringField(this, ''),
+          id: createNumberField(0),
+          userId: createStringField(''),
+          name: createStringField(''),
           image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType', 'userId'),
         }
       }

--- a/test/feature/relations-non-decorators/morph_one_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_save_custom_key.spec.ts
@@ -37,7 +37,7 @@ describe('feature/relations-non-decorators/morph_one_save_custom_key', () => {
         return {
           userId: createStringField(''),
           name: createStringField(''),
-          image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
+          image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
         }
       }
 
@@ -100,7 +100,7 @@ describe('feature/relations-non-decorators/morph_one_save_custom_key', () => {
           id: createNumberField(0),
           userId: createStringField(''),
           name: createStringField(''),
-          image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType', 'userId'),
+          image: createMorphOneRelation(Image, 'imageableId', 'imageableType', 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/morph_one_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_save_custom_key.spec.ts
@@ -37,7 +37,7 @@ describe('feature/relations-non-decorators/morph_one_save_custom_key', () => {
         return {
           userId: createStringField(''),
           name: createStringField(''),
-          image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
+          image: createMorphOneRelation(() => Image, 'imageableId', 'imageableType'),
         }
       }
 
@@ -100,7 +100,7 @@ describe('feature/relations-non-decorators/morph_one_save_custom_key', () => {
           id: createNumberField(0),
           userId: createStringField(''),
           name: createStringField(''),
-          image: createMorphOneRelation(Image, 'imageableId', 'imageableType', 'userId'),
+          image: createMorphOneRelation(() => Image, 'imageableId', 'imageableType', 'userId'),
         }
       }
 

--- a/test/feature/relations-non-decorators/morph_one_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_save_uid.spec.ts
@@ -36,7 +36,7 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
+          image: createMorphOneRelation(() => Image, 'imageableId', 'imageableType'),
         }
       }
 
@@ -99,7 +99,7 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
+          image: createMorphOneRelation(() => Image, 'imageableId', 'imageableType'),
         }
       }
 
@@ -159,7 +159,7 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
+          image: createMorphOneRelation(() => Image, 'imageableId', 'imageableType'),
         }
       }
 

--- a/test/feature/relations-non-decorators/morph_one_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_save_uid.spec.ts
@@ -16,10 +16,10 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createAttrField(this, 0),
-          url: createStringField(this, ''),
-          imageableId: createUidField(this),
-          imageableType: createStringField(this, ''),
+          id: createAttrField(0),
+          url: createStringField(''),
+          imageableId: createUidField(),
+          imageableType: createStringField(''),
         }
       }
 
@@ -34,8 +34,8 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
           image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
         }
       }
@@ -79,10 +79,10 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          url: createStringField(this, ''),
-          imageableId: createUidField(this),
-          imageableType: createStringField(this, ''),
+          id: createUidField(),
+          url: createStringField(''),
+          imageableId: createUidField(),
+          imageableType: createStringField(''),
         }
       }
 
@@ -97,8 +97,8 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
           image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
         }
       }
@@ -141,9 +141,9 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
 
       public static fields() {
         return {
-          url: createStringField(this, ''),
-          imageableId: createUidField(this),
-          imageableType: createStringField(this, ''),
+          url: createStringField(''),
+          imageableId: createUidField(),
+          imageableType: createStringField(''),
         }
       }
 
@@ -157,8 +157,8 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
           image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
         }
       }

--- a/test/feature/relations-non-decorators/morph_one_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/morph_one_save_uid.spec.ts
@@ -36,7 +36,7 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
+          image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
         }
       }
 
@@ -99,7 +99,7 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
+          image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
         }
       }
 
@@ -159,7 +159,7 @@ describe('feature/relations-non-decorators/morph_one_save_uid', () => {
         return {
           id: createUidField(),
           name: createStringField(''),
-          image: createMorphOneRelation(this, Image, 'imageableId', 'imageableType'),
+          image: createMorphOneRelation(Image, 'imageableId', 'imageableType'),
         }
       }
 

--- a/test/feature/relations-non-decorators/morph_to_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/morph_to_retrieve.spec.ts
@@ -15,7 +15,7 @@ describe('feature/relations-non-decorators/morph_to_retrieve', () => {
         url: createStringField(''),
         imageableId: createAttrField(),
         imageableType: createAttrField(),
-        imageable: createMorphToRelation(this, [User, Post], 'imageableId', 'imageableType'),
+        imageable: createMorphToRelation(() => [User, Post], 'imageableId', 'imageableType'),
       }
     }
 

--- a/test/feature/relations-non-decorators/morph_to_retrieve.spec.ts
+++ b/test/feature/relations-non-decorators/morph_to_retrieve.spec.ts
@@ -11,10 +11,10 @@ describe('feature/relations-non-decorators/morph_to_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this, 0),
-        url: createStringField(this, ''),
-        imageableId: createAttrField(this),
-        imageableType: createAttrField(this),
+        id: createAttrField(0),
+        url: createStringField(''),
+        imageableId: createAttrField(),
+        imageableType: createAttrField(),
         imageable: createMorphToRelation(this, [User, Post], 'imageableId', 'imageableType'),
       }
     }
@@ -31,8 +31,8 @@ describe('feature/relations-non-decorators/morph_to_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this, 0),
-        name: createStringField(this, ''),
+        id: createAttrField(0),
+        name: createStringField(''),
       }
     }
 
@@ -45,8 +45,8 @@ describe('feature/relations-non-decorators/morph_to_retrieve', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this, 0),
-        title: createStringField(this, ''),
+        id: createAttrField(0),
+        title: createStringField(''),
       }
     }
 

--- a/test/feature/relations-non-decorators/morph_to_save.spec.ts
+++ b/test/feature/relations-non-decorators/morph_to_save.spec.ts
@@ -14,7 +14,7 @@ describe('feature/relations-non-decorators/morph_to_save', () => {
         url: createStringField(''),
         imageableId: createAttrField(),
         imageableType: createAttrField(),
-        imageable: createMorphToRelation(this, [User], 'imageableId', 'imageableType'),
+        imageable: createMorphToRelation(() => [User], 'imageableId', 'imageableType'),
       }
     }
 

--- a/test/feature/relations-non-decorators/morph_to_save.spec.ts
+++ b/test/feature/relations-non-decorators/morph_to_save.spec.ts
@@ -10,10 +10,10 @@ describe('feature/relations-non-decorators/morph_to_save', () => {
 
     public static fields() {
       return {
-        id: createNumberField(this, 0),
-        url: createStringField(this, ''),
-        imageableId: createAttrField(this),
-        imageableType: createAttrField(this),
+        id: createNumberField(0),
+        url: createStringField(''),
+        imageableId: createAttrField(),
+        imageableType: createAttrField(),
         imageable: createMorphToRelation(this, [User], 'imageableId', 'imageableType'),
       }
     }
@@ -30,8 +30,8 @@ describe('feature/relations-non-decorators/morph_to_save', () => {
 
     public static fields() {
       return {
-        id: createNumberField(this, 0),
-        name: createStringField(this, ''),
+        id: createNumberField(0),
+        name: createStringField(''),
       }
     }
 

--- a/test/feature/relations-non-decorators/morph_to_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/morph_to_save_custom_key.spec.ts
@@ -15,10 +15,10 @@ describe('feature/relations-non-decorators/morph_to_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createNumberField(this, 0),
-          url: createStringField(this, ''),
-          imageableId: createAttrField(this),
-          imageableType: createAttrField(this),
+          id: createNumberField(0),
+          url: createStringField(''),
+          imageableId: createAttrField(),
+          imageableType: createAttrField(),
           imageable: createMorphToRelation(this, [User], 'imageableId', 'imageableType'),
         }
       }
@@ -37,8 +37,8 @@ describe('feature/relations-non-decorators/morph_to_save_custom_key', () => {
 
       public static fields() {
         return {
-          userId: createNumberField(this, 0),
-          name: createStringField(this, ''),
+          userId: createNumberField(0),
+          name: createStringField(''),
         }
       }
 
@@ -74,10 +74,10 @@ describe('feature/relations-non-decorators/morph_to_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createNumberField(this, 0),
-          url: createStringField(this, ''),
-          imageableId: createAttrField(this),
-          imageableType: createAttrField(this),
+          id: createNumberField(0),
+          url: createStringField(''),
+          imageableId: createAttrField(),
+          imageableType: createAttrField(),
           imageable: createMorphToRelation(
             this,
             [User],
@@ -100,9 +100,9 @@ describe('feature/relations-non-decorators/morph_to_save_custom_key', () => {
 
       public static fields() {
         return {
-          id: createNumberField(this, 0),
-          imageableId: createAttrField(this),
-          name: createStringField(this, ''),
+          id: createNumberField(0),
+          imageableId: createAttrField(),
+          name: createStringField(''),
         }
       }
 

--- a/test/feature/relations-non-decorators/morph_to_save_custom_key.spec.ts
+++ b/test/feature/relations-non-decorators/morph_to_save_custom_key.spec.ts
@@ -19,7 +19,7 @@ describe('feature/relations-non-decorators/morph_to_save_custom_key', () => {
           url: createStringField(''),
           imageableId: createAttrField(),
           imageableType: createAttrField(),
-          imageable: createMorphToRelation(this, [User], 'imageableId', 'imageableType'),
+          imageable: createMorphToRelation(() => [User], 'imageableId', 'imageableType'),
         }
       }
 
@@ -79,8 +79,7 @@ describe('feature/relations-non-decorators/morph_to_save_custom_key', () => {
           imageableId: createAttrField(),
           imageableType: createAttrField(),
           imageable: createMorphToRelation(
-            this,
-            [User],
+            () => [User],
             'imageableId',
             'imageableType',
             'imageableId',

--- a/test/feature/relations-non-decorators/morph_to_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/morph_to_save_uid.spec.ts
@@ -25,7 +25,7 @@ describe('feature/relations-non-decorators/morph_to_save_uid', () => {
           url: createStringField(''),
           imageableId: createAttrField(),
           imageableType: createAttrField(),
-          imageable: createMorphToRelation(this, [User], 'imageableId', 'imageableType'),
+          imageable: createMorphToRelation(() => [User], 'imageableId', 'imageableType'),
         }
       }
 
@@ -84,7 +84,7 @@ describe('feature/relations-non-decorators/morph_to_save_uid', () => {
           url: createStringField(''),
           imageableId: createAttrField(),
           imageableType: createAttrField(),
-          imageable: createMorphToRelation(this, [User], 'imageableId', 'imageableType'),
+          imageable: createMorphToRelation(() => [User], 'imageableId', 'imageableType'),
         }
       }
 

--- a/test/feature/relations-non-decorators/morph_to_save_uid.spec.ts
+++ b/test/feature/relations-non-decorators/morph_to_save_uid.spec.ts
@@ -21,10 +21,10 @@ describe('feature/relations-non-decorators/morph_to_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          url: createStringField(this, ''),
-          imageableId: createAttrField(this),
-          imageableType: createAttrField(this),
+          id: createUidField(),
+          url: createStringField(''),
+          imageableId: createAttrField(),
+          imageableType: createAttrField(),
           imageable: createMorphToRelation(this, [User], 'imageableId', 'imageableType'),
         }
       }
@@ -41,8 +41,8 @@ describe('feature/relations-non-decorators/morph_to_save_uid', () => {
 
       public static fields() {
         return {
-          id: createNumberField(this, 0),
-          name: createStringField(this, ''),
+          id: createNumberField(0),
+          name: createStringField(''),
         }
       }
 
@@ -80,10 +80,10 @@ describe('feature/relations-non-decorators/morph_to_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          url: createStringField(this, ''),
-          imageableId: createAttrField(this),
-          imageableType: createAttrField(this),
+          id: createUidField(),
+          url: createStringField(''),
+          imageableId: createAttrField(),
+          imageableType: createAttrField(),
           imageable: createMorphToRelation(this, [User], 'imageableId', 'imageableType'),
         }
       }
@@ -100,8 +100,8 @@ describe('feature/relations-non-decorators/morph_to_save_uid', () => {
 
       public static fields() {
         return {
-          id: createUidField(this),
-          name: createStringField(this, ''),
+          id: createUidField(),
+          name: createStringField(''),
         }
       }
 

--- a/test/feature/relations-non-decorators/nested/nested_relations.spec.ts
+++ b/test/feature/relations-non-decorators/nested/nested_relations.spec.ts
@@ -12,7 +12,7 @@ describe('feature/relations-non-decorators/nested/nested_relations', () => {
       return {
         id: createAttrField(),
         name: createStringField(''),
-        followers: createHasManyRelation(this, Follower, 'userId'),
+        followers: createHasManyRelation(() => Follower, 'userId'),
       }
     }
 
@@ -43,7 +43,7 @@ describe('feature/relations-non-decorators/nested/nested_relations', () => {
         id: createAttrField(),
         userId: createAttrField(),
         title: createStringField(''),
-        author: createBelongsToRelation(this, User, 'userId'),
+        author: createBelongsToRelation(() => User, 'userId'),
       }
     }
 

--- a/test/feature/relations-non-decorators/nested/nested_relations.spec.ts
+++ b/test/feature/relations-non-decorators/nested/nested_relations.spec.ts
@@ -10,8 +10,8 @@ describe('feature/relations-non-decorators/nested/nested_relations', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        name: createStringField(this, ''),
+        id: createAttrField(),
+        name: createStringField(''),
         followers: createHasManyRelation(this, Follower, 'userId'),
       }
     }
@@ -26,8 +26,8 @@ describe('feature/relations-non-decorators/nested/nested_relations', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
+        id: createAttrField(),
+        userId: createAttrField(),
       }
     }
 
@@ -40,9 +40,9 @@ describe('feature/relations-non-decorators/nested/nested_relations', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
-        title: createStringField(this, ''),
+        id: createAttrField(),
+        userId: createAttrField(),
+        title: createStringField(''),
         author: createBelongsToRelation(this, User, 'userId'),
       }
     }

--- a/test/feature/relations-non-decorators/nested/nested_revive.spec.ts
+++ b/test/feature/relations-non-decorators/nested/nested_revive.spec.ts
@@ -10,7 +10,7 @@ describe('feature/relations-non-decorators/nested/nested_revive', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
+        id: createAttrField(),
         posts: createHasManyRelation(this, Post, 'userId'),
       }
     }
@@ -24,8 +24,8 @@ describe('feature/relations-non-decorators/nested/nested_revive', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        userId: createAttrField(this),
+        id: createAttrField(),
+        userId: createAttrField(),
         author: createBelongsToRelation(this, User, 'userId'),
         comments: createHasManyRelation(this, Comment, 'postId'),
       }
@@ -42,9 +42,9 @@ describe('feature/relations-non-decorators/nested/nested_revive', () => {
 
     public static fields() {
       return {
-        id: createAttrField(this),
-        postId: createAttrField(this),
-        userId: createAttrField(this),
+        id: createAttrField(),
+        postId: createAttrField(),
+        userId: createAttrField(),
         author: createBelongsToRelation(this, User, 'userId'),
       }
     }

--- a/test/feature/relations-non-decorators/nested/nested_revive.spec.ts
+++ b/test/feature/relations-non-decorators/nested/nested_revive.spec.ts
@@ -11,7 +11,7 @@ describe('feature/relations-non-decorators/nested/nested_revive', () => {
     public static fields() {
       return {
         id: createAttrField(),
-        posts: createHasManyRelation(this, Post, 'userId'),
+        posts: createHasManyRelation(() => Post, 'userId'),
       }
     }
 
@@ -26,8 +26,8 @@ describe('feature/relations-non-decorators/nested/nested_revive', () => {
       return {
         id: createAttrField(),
         userId: createAttrField(),
-        author: createBelongsToRelation(this, User, 'userId'),
-        comments: createHasManyRelation(this, Comment, 'postId'),
+        author: createBelongsToRelation(() => User, 'userId'),
+        comments: createHasManyRelation(() => Comment, 'postId'),
       }
     }
 
@@ -45,7 +45,7 @@ describe('feature/relations-non-decorators/nested/nested_revive', () => {
         id: createAttrField(),
         postId: createAttrField(),
         userId: createAttrField(),
-        author: createBelongsToRelation(this, User, 'userId'),
+        author: createBelongsToRelation(() => User, 'userId'),
       }
     }
 


### PR DESCRIPTION
When defining models without decorators `this` is no longer required. 
For example, instead of 
```
createStringField(this, '')
```
you should do: 
```
createStringField('')
```